### PR TITLE
Refactor Vite configs and referral schema

### DIFF
--- a/admin-app/vite.config.ts
+++ b/admin-app/vite.config.ts
@@ -1,5 +1,4 @@
-/// <reference types="vitest" />
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 

--- a/referral-app/src/components/ReferralForm.tsx
+++ b/referral-app/src/components/ReferralForm.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
-import type { z } from "zod";
 import type { AxiosError } from "axios";
 import { Button } from "@bcgov/design-system-react-components";
 import {
@@ -17,11 +16,6 @@ import {
 import { useLookupData } from "../hooks";
 import { apiService } from "../services";
 
-const defaultValues: Partial<z.infer<typeof referralSchema>> = {
-  currentlyConnectedSupports: [],
-  neededSupports: [],
-};
-
 export function ReferralForm() {
   const navigate = useNavigate();
   const { regions, ministries, agencyTypes, isLoading, error } =
@@ -34,7 +28,10 @@ export function ReferralForm() {
 
   const form = useForm<ReferralFormData>({
     resolver: standardSchemaResolver(referralSchema),
-    defaultValues,
+    defaultValues: {
+      currentlyConnectedSupports: [],
+      neededSupports: [],
+    },
   });
 
   const onSubmit = async (data: ReferralFormData) => {

--- a/referral-app/src/schemas/referralSchema.ts
+++ b/referral-app/src/schemas/referralSchema.ts
@@ -16,7 +16,7 @@ export const ReferredByTypeLabels: Record<string, string> = {
 };
 
 export const ReferredByTypeOptions = Object.entries(ReferredByTypeLabels).map(
-  ([id, name]) => ({ id, name })
+  ([id, name]) => ({ id, name }),
 );
 
 export const YesNoUnknown = {
@@ -32,7 +32,7 @@ export const YesNoUnknownLabels: Record<string, string> = {
 };
 
 export const YesNoUnknownOptions = Object.entries(YesNoUnknownLabels).map(
-  ([id, name]) => ({ id, name })
+  ([id, name]) => ({ id, name }),
 );
 
 export const ReleaseFromType = {
@@ -54,7 +54,7 @@ export const ReleaseFromTypeLabels: Record<string, string> = {
 };
 
 export const ReleaseFromTypeOptions = Object.entries(ReleaseFromTypeLabels).map(
-  ([id, name]) => ({ id, name })
+  ([id, name]) => ({ id, name }),
 );
 
 export const SupportType = {
@@ -90,7 +90,7 @@ export const SupportTypeLabels: Record<string, string> = {
 };
 
 export const SupportTypeOptions = Object.entries(SupportTypeLabels).map(
-  ([id, name]) => ({ id, name })
+  ([id, name]) => ({ id, name }),
 );
 
 // Zod enums using backend values
@@ -136,13 +136,13 @@ const baseSchema = z.object({
   referredBy: ReferredByEnum,
 
   // Conditional fields for Partner Ministry (now using ID reference)
-  ministryId: z.string().uuid().optional(),
+  ministryId: z.uuid().optional(),
   ministryNameOther: z.string().optional(),
   programArea: z.string().optional(),
 
   // Conditional fields for Partner Agency
   partnerAgencyName: z.string().optional(),
-  agencyTypeId: z.string().uuid().optional(),
+  agencyTypeId: z.uuid().optional(),
   agencyTypeOther: z.string().optional(),
 
   // SDPR Internal
@@ -161,7 +161,7 @@ const baseSchema = z.object({
   gainFile: z.string().optional(),
   individualPhone: z.string().optional(),
   individualDateOfBirth: z.string().optional(),
-  regionId: z.string().uuid("Please select a region"),
+  regionId: z.uuid({ message: "Please select a region" }),
   specificCityTown: z.string().min(1, "Current city is required"),
   secondaryContact: z.string().max(100).optional(),
   bestWayToReach: z.string().max(500).optional(),
@@ -173,9 +173,9 @@ const baseSchema = z.object({
   releaseDate: z.string().optional(),
 
   // Section 4: Support Services
-  currentlyConnectedSupports: z.array(SupportTypeEnum).default([]),
+  currentlyConnectedSupports: z.array(SupportTypeEnum),
   currentlyConnectedSupportsOther: z.string().optional(),
-  neededSupports: z.array(SupportTypeEnum).default([]),
+  neededSupports: z.array(SupportTypeEnum),
   neededSupportsOther: z.string().optional(),
   referralSummary: z.string().max(5000).optional(),
 });
@@ -186,7 +186,7 @@ type BaseSchemaData = z.infer<typeof baseSchema>;
 // Validation helper functions to reduce cognitive complexity
 function validatePartnerMinistry(
   data: BaseSchemaData,
-  ctx: z.RefinementCtx
+  ctx: z.RefinementCtx,
 ): void {
   if (data.referredBy !== ReferredByType.PARTNER_MINISTRY) {
     return;
@@ -203,7 +203,7 @@ function validatePartnerMinistry(
 
 function validatePartnerAgency(
   data: BaseSchemaData,
-  ctx: z.RefinementCtx
+  ctx: z.RefinementCtx,
 ): void {
   if (data.referredBy !== ReferredByType.PARTNER_AGENCY) {
     return;
@@ -221,7 +221,7 @@ function validatePartnerAgency(
 
 function validateHousingStatus(
   data: BaseSchemaData,
-  ctx: z.RefinementCtx
+  ctx: z.RefinementCtx,
 ): void {
   const requiresLosingHousingField =
     data.currentlyHomeless === YesNoUnknown.NO ||
@@ -238,7 +238,7 @@ function validateHousingStatus(
 
 function validateSupportServices(
   data: BaseSchemaData,
-  ctx: z.RefinementCtx
+  ctx: z.RefinementCtx,
 ): void {
   if (
     data.currentlyConnectedSupports.includes(SupportType.OTHERS) &&

--- a/referral-app/vite.config.ts
+++ b/referral-app/vite.config.ts
@@ -1,5 +1,4 @@
-/// <reference types="vitest" />
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/


### PR DESCRIPTION
Update admin-app and referral-app Vite configs to import defineConfig from 'vitest/config' (Vitest API change). Clean up ReferralForm by inlining defaultValues and removing an unused z import. Adjust referralSchema: normalize map entries with trailing commas, switch string uuid validations to z.uuid, add custom regionId message, remove array .default([]) usage so defaults come from the form, and tidy validation function signatures. These changes fix type/validation mismatches and align the code with updated Vitest/Zod patterns.