### PR TITLE
Append slash to KC_URL in CSP connect-src

### DIFF
--- a/admin-app/Caddyfile
+++ b/admin-app/Caddyfile
@@ -29,7 +29,7 @@
 		Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
 		X-Content-Type-Options "nosniff"
 		Strict-Transport-Security "max-age=31536000"
-		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; frame-ancestors 'none'; form-action 'self'; connect-src 'self' {$KC_URL};"
+		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; frame-ancestors 'none'; form-action 'self'; connect-src 'self' {$KC_URL}/;"
 		Referrer-Policy "same-origin"
 		Permissions-Policy "fullscreen=(self), camera=(), microphone=()"
 		Cross-Origin-Resource-Policy "cross-origin"

--- a/referral-app/Caddyfile
+++ b/referral-app/Caddyfile
@@ -29,7 +29,7 @@
 		Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
 		X-Content-Type-Options "nosniff"
 		Strict-Transport-Security "max-age=31536000"
-		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; frame-ancestors 'none'; form-action 'self'; connect-src 'self' {$KC_URL};"
+		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; frame-ancestors 'none'; form-action 'self'; connect-src 'self' {$KC_URL}/;"
 		Referrer-Policy "same-origin"
 		Permissions-Policy "fullscreen=(self), camera=(), microphone=()"
 		Cross-Origin-Resource-Policy "cross-origin"


### PR DESCRIPTION
Update Content-Security-Policy in admin-app and referral-app Caddyfiles to change the connect-src directive from {$KC_URL} to {$KC_URL}/. This ensures the KC_URL variable includes a trailing slash when expanded, avoiding malformed/mismatched connect-src values and preventing CSP from blocking expected Keycloak connection endpoints.