### PR TITLE
Preserve Prisma CLI and add migration initContainer

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,7 +9,11 @@ RUN npm ci --prefer-offline --no-audit
 COPY . .
 RUN npx prisma generate
 RUN npm run build
+
+# Preserve prisma CLI for database migrations before pruning dev dependencies
+RUN cp -r node_modules/prisma /tmp/prisma-cli
 RUN npm prune --omit=dev
+RUN cp -r /tmp/prisma-cli node_modules/prisma
 
 FROM node:24-alpine
 WORKDIR /app
@@ -19,6 +23,7 @@ COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package*.json ./
 COPY --from=build /app/prisma ./prisma/
+COPY --from=build /app/prisma.config.ts ./
 
 EXPOSE 3000
 USER 1001

--- a/helm/backend/templates/deployment.yaml
+++ b/helm/backend/templates/deployment.yaml
@@ -22,6 +22,26 @@ spec:
           type: RuntimeDefault
       imagePullSecrets:
         - name: github-docker-registry
+      initContainers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["npx", "prisma", "migrate", "deploy"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.crunchySecret }}
+                  key: uri
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       containers:
         - name: cisb-referral-backend
           securityContext:


### PR DESCRIPTION
Keep Prisma CLI available after pruning dev dependencies by copying node_modules/prisma to /tmp before npm prune and restoring it afterward; also include prisma.config.ts in the final image. Add a Kubernetes initContainer to run `npx prisma migrate deploy` using the app image (with DB URL from a secret), with tightened securityContext and optional resource settings, ensuring migrations run at deployment time before the main backend container starts.