### PR TITLE
Add audit logging + admin UI; replace gainFile

### DIFF
--- a/admin-app/src/App.tsx
+++ b/admin-app/src/App.tsx
@@ -7,6 +7,7 @@ import {
   Ministries,
   AgencyTypes,
   Users,
+  AuditHistory,
 } from "./pages";
 
 function App() {
@@ -21,6 +22,7 @@ function App() {
           <Route path="ministries" element={<Ministries />} />
           <Route path="agency-types" element={<AgencyTypes />} />
           <Route path="users" element={<Users />} />
+          <Route path="audit-history" element={<AuditHistory />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/admin-app/src/__tests__/services/api.service.test.ts
+++ b/admin-app/src/__tests__/services/api.service.test.ts
@@ -280,6 +280,20 @@ describe("APIService methods", () => {
   });
 
   describe("users", () => {
+    it("should fetch the current user", async () => {
+      // Arrange
+      const mockUser = { id: "1", fullName: "Test User", role: "ADMIN" };
+      mockGet.mockResolvedValue({ data: mockUser });
+      const { apiService } = await import("../../services/api");
+
+      // Act
+      const result = await apiService.fetchCurrentUser();
+
+      // Assert
+      expect(mockGet).toHaveBeenCalledWith("/users/me");
+      expect(result).toEqual(mockUser);
+    });
+
     it("should fetch users without filters", async () => {
       // Arrange
       const mockUsers = [{ id: "1", name: "User A" }];

--- a/admin-app/src/components/Layout.tsx
+++ b/admin-app/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { Outlet, NavLink } from "react-router-dom";
 import { Header, Footer } from "@bcgov/design-system-react-components";
 import { logout, getUser } from "../auth";
+import { useCurrentUser } from "../hooks";
 
 /** Navigation links displayed in sidebar */
 const NAV_ITEMS = [
@@ -12,6 +13,10 @@ const NAV_ITEMS = [
   { to: "/users", label: "Users" },
 ] as const;
 
+const SYSTEM_ADMIN_NAV_ITEMS = [
+  { to: "/audit-history", label: "Audit History" },
+] as const;
+
 /**
  * Root layout with a collapsible sidebar.
  * Sidebar is always visible on md+ screens and toggles
@@ -19,6 +24,7 @@ const NAV_ITEMS = [
  */
 export function Layout() {
   const user = getUser();
+  const { isSystemAdmin } = useCurrentUser();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const toggleSidebar = useCallback(() => setSidebarOpen((o) => !o), []);
@@ -86,6 +92,24 @@ export function Layout() {
                 </NavLink>
               </li>
             ))}
+            {isSystemAdmin &&
+              SYSTEM_ADMIN_NAV_ITEMS.map((item) => (
+                <li key={item.to}>
+                  <NavLink
+                    to={item.to}
+                    onClick={closeSidebar}
+                    className={({ isActive }) =>
+                      `block py-3 px-6 text-white no-underline font-medium transition-colors hover:bg-bcgov-blue-hover ${
+                        isActive
+                          ? "bg-bcgov-blue-dark border-l-4 border-bcgov-gold pl-5"
+                          : ""
+                      }`
+                    }
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
           </ul>
           <div className="border-t border-bcgov-blue-dark mt-4 pt-4 px-4">
             {user && (

--- a/admin-app/src/components/referral/ReferrerIndividualTab.tsx
+++ b/admin-app/src/components/referral/ReferrerIndividualTab.tsx
@@ -39,7 +39,7 @@ export function ReferrerIndividualTab({
     individualPreferredName: referral.individualPreferredName,
     individualDateOfBirth: referral.individualDateOfBirth,
     individualPhone: referral.individualPhone,
-    gainFile: referral.gainFile,
+    personId: referral.personId,
     secondaryContact: referral.secondaryContact,
     bestWayToReach: referral.bestWayToReach,
     currentlyHomeless: referral.currentlyHomeless,
@@ -124,9 +124,9 @@ export function ReferrerIndividualTab({
             required
           />
           <TextInput
-            label="GAIN File (GA)"
-            value={formData.gainFile}
-            onChange={(v) => updateField("gainFile", v)}
+            label="GAIN File"
+            value={formData.personId}
+            onChange={(v) => updateField("personId", v)}
           />
           <SelectInput
             label="Experiencing Homelessness"

--- a/admin-app/src/hooks/index.ts
+++ b/admin-app/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useCurrentUser } from "./useCurrentUser";

--- a/admin-app/src/hooks/useCurrentUser.ts
+++ b/admin-app/src/hooks/useCurrentUser.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiService } from "../services/api";
+import type { User } from "../types";
+import { UserRole } from "../types";
+
+export function useCurrentUser() {
+  const { data: currentUser, isLoading } = useQuery<User>({
+    queryKey: ["current-user"],
+    queryFn: () => apiService.fetchCurrentUser(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const isSystemAdmin = currentUser?.role === UserRole.SYSTEM_ADMINISTRATOR;
+
+  return { currentUser, isLoading, isSystemAdmin };
+}

--- a/admin-app/src/pages/AuditHistory.tsx
+++ b/admin-app/src/pages/AuditHistory.tsx
@@ -1,12 +1,31 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Section } from "../ui";
-import { apiService } from "../../services/api";
-import type { ReferralAuditLogEntry } from "../../types";
+import { Navigate } from "react-router-dom";
+import { apiService } from "../services";
+import { useCurrentUser } from "../hooks";
+import type { GlobalAuditLogEntry } from "../types";
 
-interface AuditHistoryTabProps {
-  referralId: string;
-}
+const TABLE_NAME_LABELS: Record<string, string> = {
+  user: "User",
+  ministry: "Ministry",
+  agency_type: "Agency Type",
+  region: "Region",
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  CREATE: "Created",
+  UPDATE: "Updated",
+  DELETE: "Removed",
+  STATUS_CHANGE: "Status Changed",
+};
+
+const TABLE_FILTER_OPTIONS = [
+  { value: "", label: "All" },
+  { value: "user", label: "User" },
+  { value: "ministry", label: "Ministry" },
+  { value: "agency_type", label: "Agency Type" },
+  { value: "region", label: "Region" },
+] as const;
 
 function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleString("en-CA", {
@@ -18,26 +37,21 @@ function formatDate(dateStr: string): string {
   });
 }
 
-const ACTION_LABELS: Record<string, string> = {
-  CREATE: "Created",
-  UPDATE: "Updated",
-  DELETE: "Removed",
-  STATUS_CHANGE: "Status Changed",
-};
-
 interface AuditGroup {
   key: string;
   action: string;
+  tableName: string;
+  recordId: string;
   createdAt: string;
   author: string;
-  entries: ReferralAuditLogEntry[];
+  entries: GlobalAuditLogEntry[];
 }
 
-function groupLogs(logs: ReferralAuditLogEntry[]): AuditGroup[] {
+function groupLogs(logs: GlobalAuditLogEntry[]): AuditGroup[] {
   const map = new Map<string, AuditGroup>();
 
   for (const log of logs) {
-    const key = `${log.createdAt}-${log.action}-${log.referralId}`;
+    const key = `${log.createdAt}-${log.action}-${log.recordId}`;
     const existing = map.get(key);
     if (existing) {
       existing.entries.push(log);
@@ -45,6 +59,8 @@ function groupLogs(logs: ReferralAuditLogEntry[]): AuditGroup[] {
       map.set(key, {
         key,
         action: log.action,
+        tableName: log.tableName,
+        recordId: log.recordId,
         createdAt: log.createdAt,
         author: log.author?.fullName ?? "System",
         entries: [log],
@@ -74,19 +90,34 @@ function ChevronIcon({ expanded }: Readonly<{ expanded: boolean }>) {
   );
 }
 
-export function AuditHistoryTab({
-  referralId,
-}: Readonly<AuditHistoryTabProps>) {
-  const {
-    data: logs = [],
-    isLoading: loading,
-    error,
-  } = useQuery({
-    queryKey: ["referral-audit", referralId],
-    queryFn: () => apiService.fetchReferralAuditHistory(referralId),
-  });
+export function AuditHistory() {
+  const { isSystemAdmin, isLoading: isUserLoading } = useCurrentUser();
+  const [tableName, setTableName] = useState("");
+  const [page, setPage] = useState(1);
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
+  const limit = 50;
 
+  const { data, isLoading } = useQuery({
+    queryKey: ["audit-logs", tableName, page],
+    queryFn: () =>
+      apiService.fetchAuditLogs({
+        ...(tableName && { tableName }),
+        page,
+        limit,
+      }),
+    enabled: isSystemAdmin,
+  });
+
+  if (isUserLoading) {
+    return null;
+  }
+
+  if (!isSystemAdmin) {
+    return <Navigate to="/referrals" replace />;
+  }
+
+  const logs = data?.data ?? [];
+  const meta = data?.meta;
   const groups = groupLogs(logs);
 
   const toggleGroup = (key: string) => {
@@ -102,17 +133,46 @@ export function AuditHistoryTab({
   };
 
   return (
-    <Section title="Audit History">
-      <p className="text-amber-800 bg-amber-100 border border-amber-200 rounded p-3 text-sm mb-4">
-        This section is only visible to system administrators.
-      </p>
-      <div className="overflow-x-auto -mx-4 sm:mx-0">
-        <table className="w-full border-collapse text-sm min-w-[600px]">
+    <div className="p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-bcgov-blue">Audit History</h1>
+      </div>
+
+      <div className="mb-4 flex items-center gap-3">
+        <label
+          htmlFor="table-filter"
+          className="text-sm font-medium text-bcgov-gray-dark"
+        >
+          Filter by table:
+        </label>
+        <select
+          id="table-filter"
+          value={tableName}
+          onChange={(e) => {
+            setTableName(e.target.value);
+            setPage(1);
+          }}
+          className="px-3 py-1.5 border border-bcgov-blue rounded text-sm
+            focus:outline-none focus:ring-2 focus:ring-bcgov-blue"
+        >
+          {TABLE_FILTER_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-sm min-w-[700px]">
           <thead>
             <tr>
               <th className="w-8 p-3 border-b border-gray-200 bg-gray-100" />
               <th className="p-3 text-left border-b border-gray-200 bg-gray-100 font-semibold text-bcgov-gray-dark">
                 Date/Time
+              </th>
+              <th className="p-3 text-left border-b border-gray-200 bg-gray-100 font-semibold text-bcgov-gray-dark">
+                Table
               </th>
               <th className="p-3 text-left border-b border-gray-200 bg-gray-100 font-semibold text-bcgov-gray-dark">
                 Action
@@ -126,45 +186,29 @@ export function AuditHistoryTab({
             </tr>
           </thead>
           <tbody>
-            {loading && (
+            {isLoading && (
               <tr>
-                <td colSpan={5} className="text-center text-bcgov-gray p-8">
+                <td colSpan={6} className="text-center text-bcgov-gray p-8">
                   Loading audit history...
                 </td>
               </tr>
             )}
-            {error && (
+            {!isLoading && groups.length === 0 && (
               <tr>
-                <td colSpan={5} className="text-center text-red-600 p-8">
-                  Failed to load audit history.
-                </td>
-              </tr>
-            )}
-            {!loading && !error && groups.length === 0 && (
-              <tr>
-                <td colSpan={5} className="text-center text-bcgov-gray p-8">
+                <td colSpan={6} className="text-center text-bcgov-gray p-8">
                   No audit history available.
                 </td>
               </tr>
             )}
-            {!loading &&
-              !error &&
+            {!isLoading &&
               groups.map((group) => {
                 const expanded = expandedKeys.has(group.key);
-                const fieldCount = group.entries.filter((e) => e.field).length;
-
-                let summary = "—";
-                if (fieldCount > 0) {
-                  const plural = fieldCount === 1 ? "" : "s";
-                  summary = `${fieldCount} field${plural} changed`;
-                }
 
                 return (
-                  <AuditGroupRows
+                  <GroupRow
                     key={group.key}
                     group={group}
                     expanded={expanded}
-                    summary={summary}
                     onToggle={() => toggleGroup(group.key)}
                   />
                 );
@@ -172,31 +216,55 @@ export function AuditHistoryTab({
           </tbody>
         </table>
       </div>
-    </Section>
+
+      {meta && meta.totalPages > 1 && (
+        <div className="flex items-center justify-between mt-4">
+          <p className="text-sm text-bcgov-gray">
+            Page {meta.page} of {meta.totalPages} ({meta.total} total)
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+              className="px-3 py-1.5 text-sm border border-bcgov-blue rounded
+                text-bcgov-blue hover:bg-bcgov-blue hover:text-white
+                disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              disabled={page >= meta.totalPages}
+              onClick={() => setPage((p) => p + 1)}
+              className="px-3 py-1.5 text-sm border border-bcgov-blue rounded
+                text-bcgov-blue hover:bg-bcgov-blue hover:text-white
+                disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 
-interface AuditGroupRowsProps {
+interface GroupRowProps {
   group: AuditGroup;
   expanded: boolean;
-  summary: string;
   onToggle: () => void;
 }
 
-function AuditGroupRows({
-  group,
-  expanded,
-  summary,
-  onToggle,
-}: Readonly<AuditGroupRowsProps>) {
+function GroupRow({ group, expanded, onToggle }: Readonly<GroupRowProps>) {
   const fieldEntries = group.entries.filter((e) => e.field);
   const fieldCount = fieldEntries.length;
   const isExpandable = fieldCount > 1;
   const singleEntry = fieldCount === 1 ? fieldEntries[0] : null;
 
-  let displaySummary;
+  let summary;
   if (singleEntry) {
-    displaySummary = (
+    summary = (
       <span>
         <span className="font-medium">{singleEntry.field}:</span>{" "}
         {singleEntry.oldValue && (
@@ -209,9 +277,9 @@ function AuditGroupRows({
       </span>
     );
   } else if (fieldCount > 1) {
-    displaySummary = summary;
+    summary = `${fieldCount} fields changed`;
   } else {
-    displaySummary = "—";
+    summary = "—";
   }
 
   return (
@@ -224,13 +292,17 @@ function AuditGroupRows({
           {isExpandable && <ChevronIcon expanded={expanded} />}
         </td>
         <td className="p-3">{formatDate(group.createdAt)}</td>
+        <td className="p-3">
+          {TABLE_NAME_LABELS[group.tableName] ?? group.tableName}
+        </td>
         <td className="p-3">{ACTION_LABELS[group.action] ?? group.action}</td>
-        <td className="p-3 text-bcgov-gray text-xs">{displaySummary}</td>
+        <td className="p-3 text-bcgov-gray text-xs">{summary}</td>
         <td className="p-3">{group.author}</td>
       </tr>
       {expanded &&
         fieldEntries.map((entry) => (
           <tr key={entry.id} className="bg-gray-50 border-b border-gray-100">
+            <td className="p-3" />
             <td className="p-3" />
             <td className="p-3" />
             <td className="p-3 text-xs font-medium text-bcgov-gray-dark">

--- a/admin-app/src/pages/ReferralDetail.tsx
+++ b/admin-app/src/pages/ReferralDetail.tsx
@@ -8,19 +8,24 @@ import {
   AuditHistoryTab,
 } from "../components/referral";
 import { apiService } from "../services";
+import { useCurrentUser } from "../hooks";
 
 type TabType = "details" | "referrer-individual" | "related";
 
-const TABS = [
+const BASE_TABS = [
   { id: "details", label: "Referral Details" },
   { id: "referrer-individual", label: "Referrer & Individual Info" },
-  { id: "related", label: "Audit History" },
 ] as const;
+
+const AUDIT_TAB = { id: "related", label: "Audit History" } as const;
 
 export function ReferralDetail() {
   const { id } = useParams<{ id: string }>();
   const [activeTab, setActiveTab] = useState<TabType>("details");
   const queryClient = useQueryClient();
+  const { isSystemAdmin } = useCurrentUser();
+
+  const tabs = isSystemAdmin ? [...BASE_TABS, AUDIT_TAB] : BASE_TABS;
 
   const {
     data: referral,
@@ -75,7 +80,7 @@ export function ReferralDetail() {
       </div>
 
       <Tabs
-        tabs={TABS}
+        tabs={tabs}
         activeTab={activeTab}
         onTabChange={(tab) => setActiveTab(tab as TabType)}
       />
@@ -86,21 +91,29 @@ export function ReferralDetail() {
             key={referral.id}
             referral={referral}
             users={users}
-            onUpdate={() =>
-              queryClient.invalidateQueries({ queryKey: ["referral", id] })
-            }
+            onUpdate={() => {
+              queryClient.invalidateQueries({ queryKey: ["referral", id] });
+              queryClient.invalidateQueries({
+                queryKey: ["referral-audit", referral.id],
+              });
+            }}
           />
         )}
         {activeTab === "referrer-individual" && (
           <ReferrerIndividualTab
             key={referral.id}
             referral={referral}
-            onUpdate={() =>
-              queryClient.invalidateQueries({ queryKey: ["referral", id] })
-            }
+            onUpdate={() => {
+              queryClient.invalidateQueries({ queryKey: ["referral", id] });
+              queryClient.invalidateQueries({
+                queryKey: ["referral-audit", referral.id],
+              });
+            }}
           />
         )}
-        {activeTab === "related" && <AuditHistoryTab />}
+        {activeTab === "related" && isSystemAdmin && (
+          <AuditHistoryTab referralId={referral.id} />
+        )}
       </div>
     </div>
   );

--- a/admin-app/src/pages/index.ts
+++ b/admin-app/src/pages/index.ts
@@ -4,3 +4,4 @@ export { Regions } from "./Regions";
 export { Ministries } from "./Ministries";
 export { AgencyTypes } from "./AgencyTypes";
 export { Users } from "./Users";
+export { AuditHistory } from "./AuditHistory";

--- a/admin-app/src/services/api.ts
+++ b/admin-app/src/services/api.ts
@@ -11,6 +11,8 @@ import type {
   AgencyType,
   PaginatedResponse,
   FetchReferralsParams,
+  FetchAuditLogsParams,
+  GlobalAuditLogEntry,
   CreateRegionDto,
   UpdateRegionDto,
   CreateMinistryDto,
@@ -22,6 +24,7 @@ import type {
   UpdateUserDto,
   UserRole,
   UpdateReferralDto,
+  ReferralAuditLogEntry,
 } from "../types";
 import { keycloak } from "../auth";
 
@@ -147,6 +150,11 @@ class APIService {
     await this.client.delete(`/agency-types/${id}`);
   }
 
+  async fetchCurrentUser(): Promise<User> {
+    const response = await this.client.get<User>("/users/me");
+    return response.data;
+  }
+
   async fetchUsers(role?: UserRole, isActive?: boolean): Promise<User[]> {
     const params: Record<string, string> = {};
     if (role) params.role = role;
@@ -167,6 +175,24 @@ class APIService {
 
   async deleteUser(id: string): Promise<User> {
     const response = await this.client.delete<User>(`/users/${id}`);
+    return response.data;
+  }
+
+  async fetchAuditLogs(
+    params: FetchAuditLogsParams = {},
+  ): Promise<PaginatedResponse<GlobalAuditLogEntry>> {
+    const response = await this.client.get<
+      PaginatedResponse<GlobalAuditLogEntry>
+    >("/audit-logs", { params });
+    return response.data;
+  }
+
+  async fetchReferralAuditHistory(
+    referralId: string,
+  ): Promise<ReferralAuditLogEntry[]> {
+    const response = await this.client.get<ReferralAuditLogEntry[]>(
+      `/referrals/${referralId}/audit`,
+    );
     return response.data;
   }
 }

--- a/admin-app/src/types/index.ts
+++ b/admin-app/src/types/index.ts
@@ -88,7 +88,7 @@ export interface Referral {
   individualPronouns: string | null;
   individualEmail: string | null;
   individualPhone: string | null;
-  gainFile: string | null;
+  personId: string | null;
   secondaryContact: string | null;
   bestWayToReach: string | null;
   regionId: string | null;
@@ -179,7 +179,7 @@ export interface UpdateReferralDto {
   individualPreferredName?: string | null;
   individualDateOfBirth?: string | null;
   individualPhone?: string | null;
-  gainFile?: string | null;
+  personId?: string | null;
   secondaryContact?: string | null;
   bestWayToReach?: string | null;
   currentlyHomeless?: string | null;
@@ -239,4 +239,35 @@ export interface UpdateUserDto {
   contact?: string;
   role?: UserRole;
   isActive?: boolean;
+}
+
+export interface FetchAuditLogsParams {
+  tableName?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface GlobalAuditLogEntry {
+  id: string;
+  tableName: string;
+  recordId: string;
+  action: string;
+  field: string | null;
+  oldValue: string | null;
+  newValue: string | null;
+  createdAt: string;
+  createdBy: string | null;
+  author: { id: string; fullName: string } | null;
+}
+
+export interface ReferralAuditLogEntry {
+  id: string;
+  referralId: string;
+  action: string;
+  field: string | null;
+  oldValue: string | null;
+  newValue: string | null;
+  createdAt: string;
+  createdBy: string | null;
+  author: { id: string; fullName: string } | null;
 }

--- a/backend/prisma/migrations/20260414164554_add_audit_tables/migration.sql
+++ b/backend/prisma/migrations/20260414164554_add_audit_tables/migration.sql
@@ -1,0 +1,64 @@
+/*
+  Warnings:
+
+  - You are about to drop the `referral_status_history` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "referral_status_history" DROP CONSTRAINT "referral_status_history_createdBy_fkey";
+
+-- DropForeignKey
+ALTER TABLE "referral_status_history" DROP CONSTRAINT "referral_status_history_referralId_fkey";
+
+-- DropTable
+DROP TABLE "referral_status_history";
+
+-- CreateTable
+CREATE TABLE "audit_log" (
+    "id" TEXT NOT NULL,
+    "tableName" TEXT NOT NULL,
+    "recordId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "field" TEXT,
+    "oldValue" TEXT,
+    "newValue" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT,
+
+    CONSTRAINT "audit_log_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "referral_audit_log" (
+    "id" TEXT NOT NULL,
+    "referralId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "field" TEXT,
+    "oldValue" TEXT,
+    "newValue" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT,
+
+    CONSTRAINT "referral_audit_log_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "audit_log_tableName_recordId_idx" ON "audit_log"("tableName", "recordId");
+
+-- CreateIndex
+CREATE INDEX "audit_log_createdAt_idx" ON "audit_log"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "referral_audit_log_referralId_idx" ON "referral_audit_log"("referralId");
+
+-- CreateIndex
+CREATE INDEX "referral_audit_log_createdAt_idx" ON "referral_audit_log"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "audit_log" ADD CONSTRAINT "audit_log_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "referral_audit_log" ADD CONSTRAINT "referral_audit_log_referralId_fkey" FOREIGN KEY ("referralId") REFERENCES "referrals"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "referral_audit_log" ADD CONSTRAINT "referral_audit_log_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260415170940_remove_gain_file_column/migration.sql
+++ b/backend/prisma/migrations/20260415170940_remove_gain_file_column/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `gainFile` on the `referrals` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "referrals" DROP COLUMN "gainFile";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -132,7 +132,8 @@ model User {
   lastLoginAt     DateTime?
   
   assignedReferrals         Referral[]   @relation("AssignedReferrals")
-  statusHistoryEntries      ReferralStatusHistory[]
+  auditLogs                 AuditLog[]   @relation("AuditLogs")
+  referralAuditLogs         ReferralAuditLog[] @relation("ReferralAuditLogs")
 
   @@index([email])
   @@index([role])
@@ -184,7 +185,6 @@ model Referral {
   individualMiddleName  String?
   individualLastName    String?
   individualPreferredName String?
-  gainFile              String?
   individualDateOfBirth DateTime?   @db.Date
   individualPhone       String?
 
@@ -221,7 +221,7 @@ model Referral {
   createdBy             String?
   createdByContact      Contact?  @relation("CreatedReferrals", fields: [createdBy], references: [id])
   
-  statusHistory         ReferralStatusHistory[]
+  auditLogs             ReferralAuditLog[]
   
   @@index([referredBy])
   @@index([regionId])
@@ -235,18 +235,36 @@ model Referral {
   @@map("referrals")
 }
 
-model ReferralStatusHistory {
-  id            String          @id @default(uuid())
-  referralId    String
-  referral      Referral        @relation(fields: [referralId], references: [id], onDelete: Cascade)
-  fromStatus    ReferralStatus?
-  toStatus      ReferralStatus
-  comment       String?         @db.Text
-  createdAt     DateTime        @default(now())
-  createdBy     String?
-  author        User?           @relation(fields: [createdBy], references: [id])
-  
+model AuditLog {
+  id          String   @id @default(uuid())
+  tableName   String
+  recordId    String
+  action      String
+  field       String?
+  oldValue    String?  @db.Text
+  newValue    String?  @db.Text
+  createdAt   DateTime @default(now())
+  createdBy   String?
+  author      User?    @relation("AuditLogs", fields: [createdBy], references: [id])
+
+  @@index([tableName, recordId])
+  @@index([createdAt])
+  @@map("audit_log")
+}
+
+model ReferralAuditLog {
+  id          String   @id @default(uuid())
+  referralId  String
+  referral    Referral @relation(fields: [referralId], references: [id], onDelete: Cascade)
+  action      String
+  field       String?
+  oldValue    String?  @db.Text
+  newValue    String?  @db.Text
+  createdAt   DateTime @default(now())
+  createdBy   String?
+  author      User?    @relation("ReferralAuditLogs", fields: [createdBy], references: [id])
+
   @@index([referralId])
   @@index([createdAt])
-  @@map("referral_status_history")
+  @@map("referral_audit_log")
 }

--- a/backend/src/agency-types/agency-types.controller.spec.ts
+++ b/backend/src/agency-types/agency-types.controller.spec.ts
@@ -16,6 +16,8 @@ const mockAgencyType = {
   isActive: true,
 };
 
+const mockUser = { id: 'user-1' };
+
 describe('AgencyTypesController', () => {
   let controller: AgencyTypesController;
 
@@ -66,14 +68,20 @@ describe('AgencyTypesController', () => {
     it('should delegate to service with dto', async () => {
       mockAgencyTypesService.create.mockResolvedValue(mockAgencyType);
 
-      const result = await controller.create({
-        name: 'Test Agency Type',
-      } as any);
+      const result = await controller.create(
+        {
+          name: 'Test Agency Type',
+        } as any,
+        mockUser as any,
+      );
 
       expect(result).toEqual(mockAgencyType);
-      expect(mockAgencyTypesService.create).toHaveBeenCalledWith({
-        name: 'Test Agency Type',
-      });
+      expect(mockAgencyTypesService.create).toHaveBeenCalledWith(
+        {
+          name: 'Test Agency Type',
+        },
+        'user-1',
+      );
     });
   });
 
@@ -82,14 +90,19 @@ describe('AgencyTypesController', () => {
       const updated = { ...mockAgencyType, name: 'Updated Agency Type' };
       mockAgencyTypesService.update.mockResolvedValue(updated);
 
-      const result = await controller.update('agency-type-1', {
-        name: 'Updated Agency Type',
-      } as any);
+      const result = await controller.update(
+        'agency-type-1',
+        {
+          name: 'Updated Agency Type',
+        } as any,
+        mockUser as any,
+      );
 
       expect(result.name).toBe('Updated Agency Type');
       expect(mockAgencyTypesService.update).toHaveBeenCalledWith(
         'agency-type-1',
         { name: 'Updated Agency Type' },
+        'user-1',
       );
     });
   });
@@ -98,10 +111,11 @@ describe('AgencyTypesController', () => {
     it('should delegate to service with id', async () => {
       mockAgencyTypesService.remove.mockResolvedValue(mockAgencyType);
 
-      await controller.remove('agency-type-1');
+      await controller.remove('agency-type-1', mockUser as any);
 
       expect(mockAgencyTypesService.remove).toHaveBeenCalledWith(
         'agency-type-1',
+        'user-1',
       );
     });
   });

--- a/backend/src/agency-types/agency-types.controller.ts
+++ b/backend/src/agency-types/agency-types.controller.ts
@@ -26,7 +26,8 @@ import { CreateAgencyTypeDto } from './dto/create-agency-type.dto';
 import { UpdateAgencyTypeDto } from './dto/update-agency-type.dto';
 import { AgencyType, UserRole } from '../generated/prisma/client';
 import { AdminAuthGuard, RolesGuard } from '../auth/guards';
-import { Roles } from '../auth/decorators';
+import { Roles, CurrentUser } from '../auth/decorators';
+import type { User } from '../generated/prisma/client';
 
 @ApiTags('agency-types')
 @ApiBearerAuth()
@@ -86,8 +87,9 @@ export class AgencyTypesController {
   })
   async create(
     @Body() createAgencyTypeDto: CreateAgencyTypeDto,
+    @CurrentUser() user: User,
   ): Promise<AgencyType> {
-    return this.agencyTypesService.create(createAgencyTypeDto);
+    return this.agencyTypesService.create(createAgencyTypeDto, user.id);
   }
 
   @Put(':id')
@@ -113,8 +115,9 @@ export class AgencyTypesController {
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateAgencyTypeDto: UpdateAgencyTypeDto,
+    @CurrentUser() user: User,
   ): Promise<AgencyType> {
-    return this.agencyTypesService.update(id, updateAgencyTypeDto);
+    return this.agencyTypesService.update(id, updateAgencyTypeDto, user.id);
   }
 
   @Delete(':id')
@@ -129,7 +132,10 @@ export class AgencyTypesController {
     description: 'Forbidden - Insufficient permissions',
   })
   @ApiResponse({ status: 404, description: 'Agency type not found' })
-  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
-    await this.agencyTypesService.remove(id);
+  async remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: User,
+  ): Promise<void> {
+    await this.agencyTypesService.remove(id, user.id);
   }
 }

--- a/backend/src/agency-types/agency-types.module.ts
+++ b/backend/src/agency-types/agency-types.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AgencyTypesController } from './agency-types.controller';
 import { AgencyTypesService } from './agency-types.service';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
+  imports: [AuditModule],
   controllers: [AgencyTypesController],
   providers: [AgencyTypesService],
   exports: [AgencyTypesService],

--- a/backend/src/agency-types/agency-types.service.spec.ts
+++ b/backend/src/agency-types/agency-types.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException, ConflictException } from '@nestjs/common';
 import { AgencyTypesService } from './agency-types.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 import { Prisma } from '../generated/prisma/client';
 
 const mockPrismaService = {
@@ -12,6 +13,10 @@ const mockPrismaService = {
     update: jest.fn(),
     delete: jest.fn(),
   },
+};
+
+const mockAuditService = {
+  logGlobal: jest.fn().mockResolvedValue(undefined),
 };
 
 const mockAgencyType = {
@@ -30,6 +35,7 @@ describe('AgencyTypesService', () => {
       providers: [
         AgencyTypesService,
         { provide: PrismaService, useValue: mockPrismaService },
+        { provide: AuditService, useValue: mockAuditService },
       ],
     }).compile();
 
@@ -84,13 +90,25 @@ describe('AgencyTypesService', () => {
     it('should create and return an agency type', async () => {
       mockPrismaService.agencyType.create.mockResolvedValue(mockAgencyType);
 
-      const result = await service.create({
-        name: 'Test Agency Type',
-      } as any);
+      const result = await service.create(
+        {
+          name: 'Test Agency Type',
+        } as any,
+        'admin-1',
+      );
 
       expect(result).toEqual(mockAgencyType);
       expect(mockPrismaService.agencyType.create).toHaveBeenCalledWith({
         data: { name: 'Test Agency Type' },
+      });
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'agency_type',
+        recordId: 'agency-type-1',
+        action: 'CREATE',
+        changes: [
+          { field: 'name', oldValue: null, newValue: 'Test Agency Type' },
+        ],
+        userId: 'admin-1',
       });
     });
 
@@ -123,11 +141,39 @@ describe('AgencyTypesService', () => {
       mockPrismaService.agencyType.findUnique.mockResolvedValue(mockAgencyType);
       mockPrismaService.agencyType.update.mockResolvedValue(updated);
 
-      const result = await service.update('agency-type-1', {
-        name: 'Updated Agency Type',
-      } as any);
+      const result = await service.update(
+        'agency-type-1',
+        {
+          name: 'Updated Agency Type',
+        } as any,
+        'admin-1',
+      );
 
       expect(result.name).toBe('Updated Agency Type');
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'agency_type',
+        recordId: 'agency-type-1',
+        action: 'UPDATE',
+        changes: [
+          {
+            field: 'name',
+            oldValue: 'Test Agency Type',
+            newValue: 'Updated Agency Type',
+          },
+        ],
+        userId: 'admin-1',
+      });
+    });
+
+    it('should not log audit when no fields changed', async () => {
+      mockPrismaService.agencyType.findUnique.mockResolvedValue(mockAgencyType);
+      mockPrismaService.agencyType.update.mockResolvedValue(mockAgencyType);
+
+      await service.update('agency-type-1', {
+        name: 'Test Agency Type',
+      } as any);
+
+      expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException for nonexistent agency type', async () => {
@@ -157,11 +203,18 @@ describe('AgencyTypesService', () => {
       mockPrismaService.agencyType.findUnique.mockResolvedValue(mockAgencyType);
       mockPrismaService.agencyType.delete.mockResolvedValue(mockAgencyType);
 
-      const result = await service.remove('agency-type-1');
+      const result = await service.remove('agency-type-1', 'admin-1');
 
       expect(result).toEqual(mockAgencyType);
       expect(mockPrismaService.agencyType.delete).toHaveBeenCalledWith({
         where: { id: 'agency-type-1' },
+      });
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'agency_type',
+        recordId: 'agency-type-1',
+        action: 'DELETE',
+        changes: [],
+        userId: 'admin-1',
       });
     });
 

--- a/backend/src/agency-types/agency-types.service.ts
+++ b/backend/src/agency-types/agency-types.service.ts
@@ -4,13 +4,20 @@ import {
   ConflictException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { diffObjects } from '../audit/audit.utils';
 import { AgencyType, Prisma } from '../generated/prisma/client';
 import { CreateAgencyTypeDto } from './dto/create-agency-type.dto';
 import { UpdateAgencyTypeDto } from './dto/update-agency-type.dto';
 
+const TRACKED_FIELDS = ['name', 'isActive'];
+
 @Injectable()
 export class AgencyTypesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+  ) {}
 
   async findAll(activeOnly = false): Promise<AgencyType[]> {
     return this.prisma.agencyType.findMany({
@@ -33,11 +40,24 @@ export class AgencyTypesService {
     return agencyType;
   }
 
-  async create(createAgencyTypeDto: CreateAgencyTypeDto): Promise<AgencyType> {
+  async create(
+    createAgencyTypeDto: CreateAgencyTypeDto,
+    userId?: string,
+  ): Promise<AgencyType> {
     try {
-      return await this.prisma.agencyType.create({
+      const agencyType = await this.prisma.agencyType.create({
         data: createAgencyTypeDto,
       });
+
+      await this.auditService.logGlobal({
+        tableName: 'agency_type',
+        recordId: agencyType.id,
+        action: 'CREATE',
+        changes: [{ field: 'name', oldValue: null, newValue: agencyType.name }],
+        userId,
+      });
+
+      return agencyType;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (error.code === 'P2002') {
@@ -53,14 +73,33 @@ export class AgencyTypesService {
   async update(
     id: string,
     updateAgencyTypeDto: UpdateAgencyTypeDto,
+    userId?: string,
   ): Promise<AgencyType> {
-    await this.findOne(id);
+    const existing = await this.findOne(id);
+
+    const changes = diffObjects(
+      existing as unknown as Record<string, unknown>,
+      updateAgencyTypeDto as unknown as Record<string, unknown>,
+      TRACKED_FIELDS,
+    );
 
     try {
-      return await this.prisma.agencyType.update({
+      const updated = await this.prisma.agencyType.update({
         where: { id },
         data: updateAgencyTypeDto,
       });
+
+      if (changes.length > 0) {
+        await this.auditService.logGlobal({
+          tableName: 'agency_type',
+          recordId: id,
+          action: 'UPDATE',
+          changes,
+          userId,
+        });
+      }
+
+      return updated;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (error.code === 'P2002') {
@@ -73,11 +112,21 @@ export class AgencyTypesService {
     }
   }
 
-  async remove(id: string): Promise<AgencyType> {
+  async remove(id: string, userId?: string): Promise<AgencyType> {
     await this.findOne(id);
 
-    return this.prisma.agencyType.delete({
+    const removed = await this.prisma.agencyType.delete({
       where: { id },
     });
+
+    await this.auditService.logGlobal({
+      tableName: 'agency_type',
+      recordId: id,
+      action: 'DELETE',
+      changes: [],
+      userId,
+    });
+
+    return removed;
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { UsersModule } from './users/users.module';
 import { ReferralsModule } from './referrals/referrals.module';
 import { ContactsModule } from './contacts/contacts.module';
 import { AuthModule } from './auth/auth.module';
+import { AuditModule } from './audit/audit.module';
 import { HTTPLoggerMiddleware } from './middleware/req.res.logger';
 
 @Module({
@@ -20,6 +21,7 @@ import { HTTPLoggerMiddleware } from './middleware/req.res.logger';
     }),
     PrismaModule,
     AuthModule,
+    AuditModule,
     RegionsModule,
     MinistriesModule,
     AgencyTypesModule,

--- a/backend/src/audit/audit.controller.ts
+++ b/backend/src/audit/audit.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Param,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { AuditService } from './audit.service';
+import { AuditLogDto, ReferralAuditLogDto } from './dto/audit-log.dto';
+import { UserRole } from '../generated/prisma/client';
+import { AdminAuthGuard, RolesGuard } from '../auth/guards';
+import { Roles } from '../auth/decorators';
+
+@ApiTags('audit')
+@ApiBearerAuth()
+@Controller({ version: '1' })
+@UseGuards(AdminAuthGuard, RolesGuard)
+export class AuditController {
+  constructor(private readonly auditService: AuditService) {}
+
+  @Get('audit-logs')
+  @Roles(UserRole.SYSTEM_ADMINISTRATOR)
+  @ApiOperation({ summary: 'Get global audit logs' })
+  @ApiQuery({
+    name: 'tableName',
+    required: false,
+    type: String,
+    description: 'Filter by table name (user, ministry, agency_type, region)',
+  })
+  @ApiQuery({
+    name: 'recordId',
+    required: false,
+    type: String,
+    description: 'Filter by record ID',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number (default: 1)',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Items per page (default: 50)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated audit logs',
+    type: [AuditLogDto],
+  })
+  async findGlobalLogs(
+    @Query('tableName') tableName?: string,
+    @Query('recordId') recordId?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.auditService.findGlobalLogs({
+      tableName,
+      recordId,
+      page: page ? Number.parseInt(page, 10) : undefined,
+      limit: limit ? Number.parseInt(limit, 10) : undefined,
+    });
+  }
+
+  @Get('referrals/:id/audit')
+  @Roles(UserRole.SYSTEM_ADMINISTRATOR)
+  @ApiOperation({ summary: 'Get audit history for a referral' })
+  @ApiResponse({
+    status: 200,
+    description: 'Referral audit history',
+    type: [ReferralAuditLogDto],
+  })
+  @ApiResponse({ status: 404, description: 'Referral not found' })
+  async findReferralLogs(@Param('id', ParseUUIDPipe) id: string) {
+    return this.auditService.findReferralLogs(id);
+  }
+}

--- a/backend/src/audit/audit.module.ts
+++ b/backend/src/audit/audit.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuditController } from './audit.controller';
+import { AuditService } from './audit.service';
+
+@Module({
+  controllers: [AuditController],
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/backend/src/audit/audit.service.spec.ts
+++ b/backend/src/audit/audit.service.spec.ts
@@ -1,0 +1,247 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuditService } from './audit.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+const mockPrismaService = {
+  auditLog: {
+    create: jest.fn().mockResolvedValue(undefined),
+    createMany: jest.fn().mockResolvedValue({ count: 1 }),
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  referralAuditLog: {
+    create: jest.fn().mockResolvedValue(undefined),
+    createMany: jest.fn().mockResolvedValue({ count: 1 }),
+    findMany: jest.fn(),
+  },
+};
+
+describe('AuditService', () => {
+  let service: AuditService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditService,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
+    }).compile();
+
+    service = module.get<AuditService>(AuditService);
+    jest.clearAllMocks();
+  });
+
+  describe('logGlobal', () => {
+    it('should create a single entry when no changes provided', async () => {
+      await service.logGlobal({
+        tableName: 'user',
+        recordId: 'user-1',
+        action: 'DELETE',
+        userId: 'admin-1',
+      });
+
+      expect(mockPrismaService.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          tableName: 'user',
+          recordId: 'user-1',
+          action: 'DELETE',
+          createdBy: 'admin-1',
+        },
+      });
+      expect(mockPrismaService.auditLog.createMany).not.toHaveBeenCalled();
+    });
+
+    it('should create a single entry when changes is empty', async () => {
+      await service.logGlobal({
+        tableName: 'ministry',
+        recordId: 'ministry-1',
+        action: 'DELETE',
+        changes: [],
+        userId: 'admin-1',
+      });
+
+      expect(mockPrismaService.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          tableName: 'ministry',
+          recordId: 'ministry-1',
+          action: 'DELETE',
+          createdBy: 'admin-1',
+        },
+      });
+      expect(mockPrismaService.auditLog.createMany).not.toHaveBeenCalled();
+    });
+
+    it('should create multiple entries when changes are provided', async () => {
+      await service.logGlobal({
+        tableName: 'user',
+        recordId: 'user-1',
+        action: 'CREATE',
+        changes: [
+          { field: 'fullName', oldValue: null, newValue: 'Test User' },
+          { field: 'email', oldValue: null, newValue: 'test@test.com' },
+        ],
+        userId: 'admin-1',
+      });
+
+      expect(mockPrismaService.auditLog.createMany).toHaveBeenCalledWith({
+        data: [
+          {
+            tableName: 'user',
+            recordId: 'user-1',
+            action: 'CREATE',
+            field: 'fullName',
+            oldValue: null,
+            newValue: 'Test User',
+            createdBy: 'admin-1',
+          },
+          {
+            tableName: 'user',
+            recordId: 'user-1',
+            action: 'CREATE',
+            field: 'email',
+            oldValue: null,
+            newValue: 'test@test.com',
+            createdBy: 'admin-1',
+          },
+        ],
+      });
+      expect(mockPrismaService.auditLog.create).not.toHaveBeenCalled();
+    });
+
+    it('should handle missing userId', async () => {
+      await service.logGlobal({
+        tableName: 'region',
+        recordId: 'region-1',
+        action: 'DELETE',
+        changes: [],
+      });
+
+      expect(mockPrismaService.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          tableName: 'region',
+          recordId: 'region-1',
+          action: 'DELETE',
+          createdBy: undefined,
+        },
+      });
+    });
+  });
+
+  describe('logReferralChange', () => {
+    it('should create a single entry when no changes provided', async () => {
+      await service.logReferralChange({
+        referralId: 'referral-1',
+        action: 'CREATE',
+      });
+
+      expect(mockPrismaService.referralAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          referralId: 'referral-1',
+          action: 'CREATE',
+          createdBy: undefined,
+        },
+      });
+      expect(
+        mockPrismaService.referralAuditLog.createMany,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should create multiple entries when changes are provided', async () => {
+      await service.logReferralChange({
+        referralId: 'referral-1',
+        action: 'UPDATE',
+        changes: [
+          { field: 'assignedToId', oldValue: null, newValue: 'user-1' },
+        ],
+        userId: 'admin-1',
+      });
+
+      expect(
+        mockPrismaService.referralAuditLog.createMany,
+      ).toHaveBeenCalledWith({
+        data: [
+          {
+            referralId: 'referral-1',
+            action: 'UPDATE',
+            field: 'assignedToId',
+            oldValue: null,
+            newValue: 'user-1',
+            createdBy: 'admin-1',
+          },
+        ],
+      });
+      expect(mockPrismaService.referralAuditLog.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findGlobalLogs', () => {
+    it('should return paginated results with metadata', async () => {
+      const mockLogs = [{ id: 'log-1', tableName: 'user', action: 'CREATE' }];
+      mockPrismaService.auditLog.findMany.mockResolvedValue(mockLogs);
+      mockPrismaService.auditLog.count.mockResolvedValue(1);
+
+      const result = await service.findGlobalLogs({ page: 1, limit: 50 });
+
+      expect(result.data).toEqual(mockLogs);
+      expect(result.meta).toEqual({
+        total: 1,
+        page: 1,
+        limit: 50,
+        totalPages: 1,
+      });
+      expect(mockPrismaService.auditLog.findMany).toHaveBeenCalledWith({
+        where: {},
+        skip: 0,
+        take: 50,
+        orderBy: { createdAt: 'desc' },
+        include: { author: { select: { id: true, fullName: true } } },
+      });
+    });
+
+    it('should filter by tableName', async () => {
+      mockPrismaService.auditLog.findMany.mockResolvedValue([]);
+      mockPrismaService.auditLog.count.mockResolvedValue(0);
+
+      await service.findGlobalLogs({ tableName: 'user' });
+
+      expect(mockPrismaService.auditLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { tableName: 'user' },
+        }),
+      );
+    });
+
+    it('should calculate correct pagination offset', async () => {
+      mockPrismaService.auditLog.findMany.mockResolvedValue([]);
+      mockPrismaService.auditLog.count.mockResolvedValue(100);
+
+      const result = await service.findGlobalLogs({ page: 3, limit: 10 });
+
+      expect(mockPrismaService.auditLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 20,
+          take: 10,
+        }),
+      );
+      expect(result.meta.totalPages).toBe(10);
+    });
+  });
+
+  describe('findReferralLogs', () => {
+    it('should return audit logs for a referral', async () => {
+      const mockLogs = [
+        { id: 'log-1', referralId: 'referral-1', action: 'CREATE' },
+      ];
+      mockPrismaService.referralAuditLog.findMany.mockResolvedValue(mockLogs);
+
+      const result = await service.findReferralLogs('referral-1');
+
+      expect(result).toEqual(mockLogs);
+      expect(mockPrismaService.referralAuditLog.findMany).toHaveBeenCalledWith({
+        where: { referralId: 'referral-1' },
+        orderBy: { createdAt: 'desc' },
+        include: { author: { select: { id: true, fullName: true } } },
+      });
+    });
+  });
+});

--- a/backend/src/audit/audit.service.ts
+++ b/backend/src/audit/audit.service.ts
@@ -1,0 +1,139 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditLog, ReferralAuditLog } from '../generated/prisma/client';
+import { FieldChange } from './audit.utils';
+
+export interface GlobalAuditParams {
+  tableName: string;
+  recordId: string;
+  action: string;
+  changes?: FieldChange[];
+  userId?: string;
+}
+
+export interface ReferralAuditParams {
+  referralId: string;
+  action: string;
+  changes?: FieldChange[];
+  userId?: string;
+}
+
+@Injectable()
+export class AuditService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Log one or more global audit entries (users, ministries, etc.).
+   * For CREATE/DELETE: a single entry with the record identifier.
+   * For UPDATE: one entry per changed field.
+   */
+  async logGlobal(params: GlobalAuditParams): Promise<void> {
+    const { tableName, recordId, action, changes, userId } = params;
+
+    if (changes && changes.length > 0) {
+      await this.prisma.auditLog.createMany({
+        data: changes.map((change) => ({
+          tableName,
+          recordId,
+          action,
+          field: change.field,
+          oldValue: change.oldValue,
+          newValue: change.newValue,
+          createdBy: userId,
+        })),
+      });
+    } else {
+      await this.prisma.auditLog.create({
+        data: {
+          tableName,
+          recordId,
+          action,
+          createdBy: userId,
+        },
+      });
+    }
+  }
+
+  /**
+   * Log one or more referral audit entries.
+   * For CREATE: a single entry marking creation.
+   * For UPDATE: one entry per changed field.
+   */
+  async logReferralChange(params: ReferralAuditParams): Promise<void> {
+    const { referralId, action, changes, userId } = params;
+
+    if (changes && changes.length > 0) {
+      await this.prisma.referralAuditLog.createMany({
+        data: changes.map((change) => ({
+          referralId,
+          action,
+          field: change.field,
+          oldValue: change.oldValue,
+          newValue: change.newValue,
+          createdBy: userId,
+        })),
+      });
+    } else {
+      await this.prisma.referralAuditLog.create({
+        data: {
+          referralId,
+          action,
+          createdBy: userId,
+        },
+      });
+    }
+  }
+
+  /**
+   * Query global audit logs with optional filters and pagination.
+   */
+  async findGlobalLogs(filters: {
+    tableName?: string;
+    recordId?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<{
+    data: AuditLog[];
+    meta: { total: number; page: number; limit: number; totalPages: number };
+  }> {
+    const { tableName, recordId, page = 1, limit = 50 } = filters;
+    const skip = (page - 1) * limit;
+
+    const where = {
+      ...(tableName && { tableName }),
+      ...(recordId && { recordId }),
+    };
+
+    const [data, total] = await Promise.all([
+      this.prisma.auditLog.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        include: { author: { select: { id: true, fullName: true } } },
+      }),
+      this.prisma.auditLog.count({ where }),
+    ]);
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * Get all audit log entries for a specific referral.
+   */
+  async findReferralLogs(referralId: string): Promise<ReferralAuditLog[]> {
+    return this.prisma.referralAuditLog.findMany({
+      where: { referralId },
+      orderBy: { createdAt: 'desc' },
+      include: { author: { select: { id: true, fullName: true } } },
+    });
+  }
+}

--- a/backend/src/audit/audit.utils.spec.ts
+++ b/backend/src/audit/audit.utils.spec.ts
@@ -1,0 +1,110 @@
+import { diffObjects, serializeValue } from './audit.utils';
+
+describe('audit.utils', () => {
+  describe('serializeValue', () => {
+    it('should return null for null', () => {
+      expect(serializeValue(null)).toBeNull();
+    });
+
+    it('should return null for undefined', () => {
+      expect(serializeValue(undefined)).toBeNull();
+    });
+
+    it('should serialize strings as-is', () => {
+      expect(serializeValue('hello')).toBe('hello');
+    });
+
+    it('should serialize numbers to string', () => {
+      expect(serializeValue(42)).toBe('42');
+    });
+
+    it('should serialize booleans to string', () => {
+      expect(serializeValue(true)).toBe('true');
+      expect(serializeValue(false)).toBe('false');
+    });
+
+    it('should serialize dates to ISO string', () => {
+      const date = new Date('2026-01-15T12:00:00.000Z');
+      expect(serializeValue(date)).toBe('2026-01-15T12:00:00.000Z');
+    });
+
+    it('should serialize arrays to JSON', () => {
+      expect(serializeValue(['a', 'b'])).toBe('["a","b"]');
+    });
+  });
+
+  describe('diffObjects', () => {
+    it('should detect changed fields', () => {
+      const oldObj = { name: 'Old', email: 'old@test.com' };
+      const newObj = { name: 'New' };
+
+      const changes = diffObjects(oldObj, newObj, ['name', 'email']);
+
+      expect(changes).toEqual([
+        { field: 'name', oldValue: 'Old', newValue: 'New' },
+      ]);
+    });
+
+    it('should skip fields not in newObj', () => {
+      const oldObj = { name: 'Old', email: 'old@test.com' };
+      const newObj = { name: 'Old' };
+
+      const changes = diffObjects(oldObj, newObj, ['name', 'email']);
+
+      expect(changes).toEqual([]);
+    });
+
+    it('should return empty array when no fields changed', () => {
+      const oldObj = { name: 'Same' };
+      const newObj = { name: 'Same' };
+
+      const changes = diffObjects(oldObj, newObj, ['name']);
+
+      expect(changes).toEqual([]);
+    });
+
+    it('should detect null to value changes', () => {
+      const oldObj = { name: null };
+      const newObj = { name: 'New' };
+
+      const changes = diffObjects(oldObj, newObj, ['name']);
+
+      expect(changes).toEqual([
+        { field: 'name', oldValue: null, newValue: 'New' },
+      ]);
+    });
+
+    it('should detect value to null changes', () => {
+      const oldObj = { name: 'Old' };
+      const newObj = { name: null };
+
+      const changes = diffObjects(oldObj, newObj, ['name']);
+
+      expect(changes).toEqual([
+        { field: 'name', oldValue: 'Old', newValue: null },
+      ]);
+    });
+
+    it('should only track specified fields', () => {
+      const oldObj = { name: 'Old', secret: 'a' };
+      const newObj = { name: 'New', secret: 'b' };
+
+      const changes = diffObjects(oldObj, newObj, ['name']);
+
+      expect(changes).toEqual([
+        { field: 'name', oldValue: 'Old', newValue: 'New' },
+      ]);
+    });
+
+    it('should serialize boolean changes', () => {
+      const oldObj = { isActive: true };
+      const newObj = { isActive: false };
+
+      const changes = diffObjects(oldObj, newObj, ['isActive']);
+
+      expect(changes).toEqual([
+        { field: 'isActive', oldValue: 'true', newValue: 'false' },
+      ]);
+    });
+  });
+});

--- a/backend/src/audit/audit.utils.spec.ts
+++ b/backend/src/audit/audit.utils.spec.ts
@@ -31,6 +31,10 @@ describe('audit.utils', () => {
     it('should serialize arrays to JSON', () => {
       expect(serializeValue(['a', 'b'])).toBe('["a","b"]');
     });
+
+    it('should serialize objects to JSON', () => {
+      expect(serializeValue({ key: 'val' })).toBe('{"key":"val"}');
+    });
   });
 
   describe('diffObjects', () => {

--- a/backend/src/audit/audit.utils.ts
+++ b/backend/src/audit/audit.utils.ts
@@ -20,7 +20,7 @@ export function diffObjects(
   const changes: FieldChange[] = [];
 
   for (const field of trackedFields) {
-    if (!(field in newObj)) {
+    if (!Object.hasOwn(newObj, field)) {
       continue;
     }
 
@@ -55,7 +55,7 @@ export function serializeValue(value: unknown): string | null {
     return value.toISOString();
   }
 
-  if (Array.isArray(value)) {
+  if (typeof value === 'object' || Array.isArray(value)) {
     return JSON.stringify(value);
   }
 

--- a/backend/src/audit/audit.utils.ts
+++ b/backend/src/audit/audit.utils.ts
@@ -1,0 +1,63 @@
+/**
+ * Compares two objects and returns an array of changed fields.
+ * Values are serialized to strings for consistent audit storage.
+ */
+export interface FieldChange {
+  field: string;
+  oldValue: string | null;
+  newValue: string | null;
+}
+
+/**
+ * Compares old and new objects for the given tracked fields.
+ * Returns an array of changes where the value actually differs.
+ */
+export function diffObjects(
+  oldObj: Record<string, unknown>,
+  newObj: Record<string, unknown>,
+  trackedFields: string[],
+): FieldChange[] {
+  const changes: FieldChange[] = [];
+
+  for (const field of trackedFields) {
+    if (!(field in newObj)) {
+      continue;
+    }
+
+    const oldVal = oldObj[field];
+    const newVal = newObj[field];
+
+    const oldStr = serializeValue(oldVal);
+    const newStr = serializeValue(newVal);
+
+    if (oldStr !== newStr) {
+      changes.push({
+        field,
+        oldValue: oldStr,
+        newValue: newStr,
+      });
+    }
+  }
+
+  return changes;
+}
+
+/**
+ * Serializes a value to a string for audit log storage.
+ * Arrays are JSON-serialized; null/undefined become null.
+ */
+export function serializeValue(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}

--- a/backend/src/audit/dto/audit-log.dto.ts
+++ b/backend/src/audit/dto/audit-log.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AuditLogDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  tableName!: string;
+
+  @ApiProperty()
+  recordId!: string;
+
+  @ApiProperty()
+  action!: string;
+
+  @ApiPropertyOptional()
+  field?: string | null;
+
+  @ApiPropertyOptional()
+  oldValue?: string | null;
+
+  @ApiPropertyOptional()
+  newValue?: string | null;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiPropertyOptional()
+  createdBy?: string | null;
+
+  @ApiPropertyOptional()
+  author?: { id: string; fullName: string } | null;
+}
+
+export class ReferralAuditLogDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  referralId!: string;
+
+  @ApiProperty()
+  action!: string;
+
+  @ApiPropertyOptional()
+  field?: string | null;
+
+  @ApiPropertyOptional()
+  oldValue?: string | null;
+
+  @ApiPropertyOptional()
+  newValue?: string | null;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiPropertyOptional()
+  createdBy?: string | null;
+
+  @ApiPropertyOptional()
+  author?: { id: string; fullName: string } | null;
+}

--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -1,0 +1,3 @@
+export * from './audit.module';
+export * from './audit.service';
+export * from './audit.utils';

--- a/backend/src/auth/strategies/admin-jwt.strategy.ts
+++ b/backend/src/auth/strategies/admin-jwt.strategy.ts
@@ -49,8 +49,9 @@ export class AdminJwtStrategy extends PassportStrategy(Strategy, 'admin-jwt') {
 
     // If not found by keycloakId, try by email and auto-link
     if (!user && email) {
+      const normalizedEmail = email.toLowerCase();
       user = await this.prisma.user.findUnique({
-        where: { email },
+        where: { email: normalizedEmail },
       });
 
       if (user && !user.keycloakId) {

--- a/backend/src/ministries/ministries.controller.spec.ts
+++ b/backend/src/ministries/ministries.controller.spec.ts
@@ -16,6 +16,8 @@ const mockMinistry = {
   isActive: true,
 };
 
+const mockUser = { id: 'user-1' };
+
 describe('MinistriesController', () => {
   let controller: MinistriesController;
 
@@ -64,14 +66,20 @@ describe('MinistriesController', () => {
     it('should delegate to service with dto', async () => {
       mockMinistriesService.create.mockResolvedValue(mockMinistry);
 
-      const result = await controller.create({
-        name: 'Test Ministry',
-      } as any);
+      const result = await controller.create(
+        {
+          name: 'Test Ministry',
+        } as any,
+        mockUser as any,
+      );
 
       expect(result).toEqual(mockMinistry);
-      expect(mockMinistriesService.create).toHaveBeenCalledWith({
-        name: 'Test Ministry',
-      });
+      expect(mockMinistriesService.create).toHaveBeenCalledWith(
+        {
+          name: 'Test Ministry',
+        },
+        'user-1',
+      );
     });
   });
 
@@ -80,14 +88,22 @@ describe('MinistriesController', () => {
       const updated = { ...mockMinistry, name: 'Updated Ministry' };
       mockMinistriesService.update.mockResolvedValue(updated);
 
-      const result = await controller.update('ministry-1', {
-        name: 'Updated Ministry',
-      } as any);
+      const result = await controller.update(
+        'ministry-1',
+        {
+          name: 'Updated Ministry',
+        } as any,
+        mockUser as any,
+      );
 
       expect(result.name).toBe('Updated Ministry');
-      expect(mockMinistriesService.update).toHaveBeenCalledWith('ministry-1', {
-        name: 'Updated Ministry',
-      });
+      expect(mockMinistriesService.update).toHaveBeenCalledWith(
+        'ministry-1',
+        {
+          name: 'Updated Ministry',
+        },
+        'user-1',
+      );
     });
   });
 
@@ -95,9 +111,12 @@ describe('MinistriesController', () => {
     it('should delegate to service with id', async () => {
       mockMinistriesService.remove.mockResolvedValue(mockMinistry);
 
-      await controller.remove('ministry-1');
+      await controller.remove('ministry-1', mockUser as any);
 
-      expect(mockMinistriesService.remove).toHaveBeenCalledWith('ministry-1');
+      expect(mockMinistriesService.remove).toHaveBeenCalledWith(
+        'ministry-1',
+        'user-1',
+      );
     });
   });
 });

--- a/backend/src/ministries/ministries.controller.ts
+++ b/backend/src/ministries/ministries.controller.ts
@@ -26,7 +26,8 @@ import { CreateMinistryDto } from './dto/create-ministry.dto';
 import { UpdateMinistryDto } from './dto/update-ministry.dto';
 import { Ministry, UserRole } from '../generated/prisma/client';
 import { AdminAuthGuard, RolesGuard } from '../auth/guards';
-import { Roles } from '../auth/decorators';
+import { Roles, CurrentUser } from '../auth/decorators';
+import type { User } from '../generated/prisma/client';
 
 @ApiTags('ministries')
 @ApiBearerAuth()
@@ -86,8 +87,9 @@ export class MinistriesController {
   })
   async create(
     @Body() createMinistryDto: CreateMinistryDto,
+    @CurrentUser() user: User,
   ): Promise<Ministry> {
-    return this.ministriesService.create(createMinistryDto);
+    return this.ministriesService.create(createMinistryDto, user.id);
   }
 
   @Put(':id')
@@ -113,8 +115,9 @@ export class MinistriesController {
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateMinistryDto: UpdateMinistryDto,
+    @CurrentUser() user: User,
   ): Promise<Ministry> {
-    return this.ministriesService.update(id, updateMinistryDto);
+    return this.ministriesService.update(id, updateMinistryDto, user.id);
   }
 
   @Delete(':id')
@@ -129,7 +132,10 @@ export class MinistriesController {
     description: 'Forbidden - Insufficient permissions',
   })
   @ApiResponse({ status: 404, description: 'Ministry not found' })
-  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
-    await this.ministriesService.remove(id);
+  async remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: User,
+  ): Promise<void> {
+    await this.ministriesService.remove(id, user.id);
   }
 }

--- a/backend/src/ministries/ministries.module.ts
+++ b/backend/src/ministries/ministries.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { MinistriesController } from './ministries.controller';
 import { MinistriesService } from './ministries.service';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
+  imports: [AuditModule],
   controllers: [MinistriesController],
   providers: [MinistriesService],
   exports: [MinistriesService],

--- a/backend/src/ministries/ministries.service.spec.ts
+++ b/backend/src/ministries/ministries.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException, ConflictException } from '@nestjs/common';
 import { MinistriesService } from './ministries.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 import { Prisma } from '../generated/prisma/client';
 
 const mockPrismaService = {
@@ -12,6 +13,10 @@ const mockPrismaService = {
     update: jest.fn(),
     delete: jest.fn(),
   },
+};
+
+const mockAuditService = {
+  logGlobal: jest.fn().mockResolvedValue(undefined),
 };
 
 const mockMinistry = {
@@ -30,6 +35,7 @@ describe('MinistriesService', () => {
       providers: [
         MinistriesService,
         { provide: PrismaService, useValue: mockPrismaService },
+        { provide: AuditService, useValue: mockAuditService },
       ],
     }).compile();
 
@@ -84,11 +90,21 @@ describe('MinistriesService', () => {
     it('should create and return a ministry', async () => {
       mockPrismaService.ministry.create.mockResolvedValue(mockMinistry);
 
-      const result = await service.create({ name: 'Test Ministry' } as any);
+      const result = await service.create(
+        { name: 'Test Ministry' } as any,
+        'admin-1',
+      );
 
       expect(result).toEqual(mockMinistry);
       expect(mockPrismaService.ministry.create).toHaveBeenCalledWith({
         data: { name: 'Test Ministry' },
+      });
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'ministry',
+        recordId: 'ministry-1',
+        action: 'CREATE',
+        changes: [{ field: 'name', oldValue: null, newValue: 'Test Ministry' }],
+        userId: 'admin-1',
       });
     });
 
@@ -121,11 +137,39 @@ describe('MinistriesService', () => {
       mockPrismaService.ministry.findUnique.mockResolvedValue(mockMinistry);
       mockPrismaService.ministry.update.mockResolvedValue(updated);
 
-      const result = await service.update('ministry-1', {
-        name: 'Updated Ministry',
-      } as any);
+      const result = await service.update(
+        'ministry-1',
+        {
+          name: 'Updated Ministry',
+        } as any,
+        'admin-1',
+      );
 
       expect(result.name).toBe('Updated Ministry');
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'ministry',
+        recordId: 'ministry-1',
+        action: 'UPDATE',
+        changes: [
+          {
+            field: 'name',
+            oldValue: 'Test Ministry',
+            newValue: 'Updated Ministry',
+          },
+        ],
+        userId: 'admin-1',
+      });
+    });
+
+    it('should not log audit when no fields changed', async () => {
+      mockPrismaService.ministry.findUnique.mockResolvedValue(mockMinistry);
+      mockPrismaService.ministry.update.mockResolvedValue(mockMinistry);
+
+      await service.update('ministry-1', {
+        name: 'Test Ministry',
+      } as any);
+
+      expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException for nonexistent ministry', async () => {
@@ -155,11 +199,18 @@ describe('MinistriesService', () => {
       mockPrismaService.ministry.findUnique.mockResolvedValue(mockMinistry);
       mockPrismaService.ministry.delete.mockResolvedValue(mockMinistry);
 
-      const result = await service.remove('ministry-1');
+      const result = await service.remove('ministry-1', 'admin-1');
 
       expect(result).toEqual(mockMinistry);
       expect(mockPrismaService.ministry.delete).toHaveBeenCalledWith({
         where: { id: 'ministry-1' },
+      });
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'ministry',
+        recordId: 'ministry-1',
+        action: 'DELETE',
+        changes: [],
+        userId: 'admin-1',
       });
     });
 

--- a/backend/src/ministries/ministries.service.ts
+++ b/backend/src/ministries/ministries.service.ts
@@ -4,13 +4,20 @@ import {
   ConflictException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { diffObjects } from '../audit/audit.utils';
 import { Ministry, Prisma } from '../generated/prisma/client';
 import { CreateMinistryDto } from './dto/create-ministry.dto';
 import { UpdateMinistryDto } from './dto/update-ministry.dto';
 
+const TRACKED_FIELDS = ['name', 'isActive'];
+
 @Injectable()
 export class MinistriesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+  ) {}
 
   async findAll(activeOnly = false): Promise<Ministry[]> {
     return this.prisma.ministry.findMany({
@@ -33,11 +40,24 @@ export class MinistriesService {
     return ministry;
   }
 
-  async create(createMinistryDto: CreateMinistryDto): Promise<Ministry> {
+  async create(
+    createMinistryDto: CreateMinistryDto,
+    userId?: string,
+  ): Promise<Ministry> {
     try {
-      return await this.prisma.ministry.create({
+      const ministry = await this.prisma.ministry.create({
         data: createMinistryDto,
       });
+
+      await this.auditService.logGlobal({
+        tableName: 'ministry',
+        recordId: ministry.id,
+        action: 'CREATE',
+        changes: [{ field: 'name', oldValue: null, newValue: ministry.name }],
+        userId,
+      });
+
+      return ministry;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (error.code === 'P2002') {
@@ -53,14 +73,33 @@ export class MinistriesService {
   async update(
     id: string,
     updateMinistryDto: UpdateMinistryDto,
+    userId?: string,
   ): Promise<Ministry> {
-    await this.findOne(id);
+    const existing = await this.findOne(id);
+
+    const changes = diffObjects(
+      existing as unknown as Record<string, unknown>,
+      updateMinistryDto as unknown as Record<string, unknown>,
+      TRACKED_FIELDS,
+    );
 
     try {
-      return await this.prisma.ministry.update({
+      const updated = await this.prisma.ministry.update({
         where: { id },
         data: updateMinistryDto,
       });
+
+      if (changes.length > 0) {
+        await this.auditService.logGlobal({
+          tableName: 'ministry',
+          recordId: id,
+          action: 'UPDATE',
+          changes,
+          userId,
+        });
+      }
+
+      return updated;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (error.code === 'P2002') {
@@ -73,11 +112,21 @@ export class MinistriesService {
     }
   }
 
-  async remove(id: string): Promise<Ministry> {
+  async remove(id: string, userId?: string): Promise<Ministry> {
     await this.findOne(id);
 
-    return this.prisma.ministry.delete({
+    const removed = await this.prisma.ministry.delete({
       where: { id },
     });
+
+    await this.auditService.logGlobal({
+      tableName: 'ministry',
+      recordId: id,
+      action: 'DELETE',
+      changes: [],
+      userId,
+    });
+
+    return removed;
   }
 }

--- a/backend/src/referrals/dto/create-referral.dto.ts
+++ b/backend/src/referrals/dto/create-referral.dto.ts
@@ -130,11 +130,6 @@ export class CreateReferralDto {
 
   @ApiProperty({ required: false })
   @IsOptional()
-  @IsString()
-  gainFile?: string;
-
-  @ApiProperty({ required: false })
-  @IsOptional()
   @IsDateString()
   individualDateOfBirth?: string;
 

--- a/backend/src/referrals/dto/update-referral.dto.ts
+++ b/backend/src/referrals/dto/update-referral.dto.ts
@@ -201,7 +201,7 @@ export class UpdateReferralDto {
   @ApiProperty({ required: false })
   @IsOptional()
   @IsString()
-  gainFile?: string;
+  personId?: string;
 
   @ApiProperty({ required: false })
   @IsOptional()

--- a/backend/src/referrals/referrals.module.ts
+++ b/backend/src/referrals/referrals.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ReferralsController } from './referrals.controller';
 import { ReferralsService } from './referrals.service';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
+  imports: [AuditModule],
   controllers: [ReferralsController],
   providers: [ReferralsService],
   exports: [ReferralsService],

--- a/backend/src/referrals/referrals.service.spec.ts
+++ b/backend/src/referrals/referrals.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { ReferralsService } from './referrals.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 import {
   ReferredByType,
   YesNoUnknown,
@@ -89,6 +90,10 @@ describe('ReferralsService', () => {
     },
   };
 
+  const mockAuditService = {
+    logReferralChange: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -96,6 +101,7 @@ describe('ReferralsService', () => {
       providers: [
         ReferralsService,
         { provide: PrismaService, useValue: mockPrismaService },
+        { provide: AuditService, useValue: mockAuditService },
       ],
     }).compile();
 
@@ -331,6 +337,10 @@ describe('ReferralsService', () => {
           }),
         }),
       );
+      expect(mockAuditService.logReferralChange).toHaveBeenCalledWith({
+        referralId: expected.id,
+        action: 'CREATE',
+      });
     });
 
     it('should convert date strings to Date objects', async () => {
@@ -536,6 +546,14 @@ describe('ReferralsService', () => {
           }),
         }),
       );
+      expect(mockAuditService.logReferralChange).toHaveBeenCalledWith({
+        referralId: 'referral-uuid-1',
+        action: 'UPDATE',
+        changes: expect.arrayContaining([
+          expect.objectContaining({ field: 'assignedToId' }),
+        ]),
+        userId: 'admin-uuid-1',
+      });
     });
 
     it('should create status history when status changes', async () => {
@@ -554,6 +572,14 @@ describe('ReferralsService', () => {
       await service.update('referral-uuid-1', updateDto, 'admin-uuid-1');
 
       expect(mockPrismaService.referral.update).toHaveBeenCalled();
+      expect(mockAuditService.logReferralChange).toHaveBeenCalledWith({
+        referralId: 'referral-uuid-1',
+        action: 'STATUS_CHANGE',
+        changes: expect.arrayContaining([
+          expect.objectContaining({ field: 'referralStatus' }),
+        ]),
+        userId: 'admin-uuid-1',
+      });
     });
 
     it('should not create status history when status is unchanged', async () => {

--- a/backend/src/referrals/referrals.service.ts
+++ b/backend/src/referrals/referrals.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { diffObjects } from '../audit/audit.utils';
 import {
   CreateReferralDto,
   YesNoUnknown,
@@ -8,12 +10,58 @@ import {
 import { UpdateReferralDto, ReferralStatus } from './dto/update-referral.dto';
 import { Referral } from '../generated/prisma/client';
 
+const TRACKED_FIELDS = [
+  'referralStatus',
+  'referralOutcome',
+  'assignedToId',
+  'communityPartnerName',
+  'flag',
+  'followUpDate',
+  'dueDate',
+  'completedDate',
+  'assignedOn',
+  'firstContactMadeOn',
+  'currentlyConnectedSupports',
+  'currentlyConnectedSupportsOther',
+  'regionId',
+  'specificCityTown',
+  'neededSupports',
+  'neededSupportsOther',
+  'referralSummary',
+  'referredBy',
+  'ministryId',
+  'ministryNameOther',
+  'agencyTypeId',
+  'agencyTypeOther',
+  'partnerAgencyName',
+  'programArea',
+  'referrerContactName',
+  'referrerEmail',
+  'referrerPhone',
+  'individualFirstName',
+  'individualMiddleName',
+  'individualLastName',
+  'individualPreferredName',
+  'individualDateOfBirth',
+  'individualPhone',
+  'personId',
+  'secondaryContact',
+  'bestWayToReach',
+  'currentlyHomeless',
+  'losingHousing',
+  'pendingRelease',
+  'releaseDate',
+];
+
 @Injectable()
 export class ReferralsService {
   private static readonly URGENT_RELEASE_WINDOW_DAYS = 4;
   private static readonly MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+  ) {}
 
   private calculateFlag(
     experiencingHomelessnessResponse?: YesNoUnknown,
@@ -77,7 +125,7 @@ export class ReferralsService {
       createReferralDto.releaseDate,
     );
 
-    return this.prisma.referral.create({
+    const referral = await this.prisma.referral.create({
       data: {
         ...createReferralDto,
         individualDateOfBirth: createReferralDto.individualDateOfBirth
@@ -96,6 +144,13 @@ export class ReferralsService {
         agencyType: true,
       },
     });
+
+    await this.auditService.logReferralChange({
+      referralId: referral.id,
+      action: 'CREATE',
+    });
+
+    return referral;
   }
 
   async findAll(params: {
@@ -169,27 +224,86 @@ export class ReferralsService {
     updateReferralDto: UpdateReferralDto,
     userId?: string,
   ): Promise<Referral> {
-    await this.findOne(id);
+    const existing = await this.findOne(id);
 
-    return this.prisma.referral.update({
+    const updateData: Record<string, unknown> = {
+      referralStatus: updateReferralDto.referralStatus,
+      assignedToId: updateReferralDto.assignedToId,
+      referralOutcome: updateReferralDto.referralOutcome,
+      communityPartnerName: updateReferralDto.communityPartnerName,
+      flag: updateReferralDto.flag,
+      modifiedBy: userId,
+      followUpDate: updateReferralDto.followUpDate
+        ? new Date(updateReferralDto.followUpDate)
+        : undefined,
+      dueDate: updateReferralDto.dueDate
+        ? new Date(updateReferralDto.dueDate)
+        : undefined,
+      completedDate: updateReferralDto.completedDate
+        ? new Date(updateReferralDto.completedDate)
+        : undefined,
+      assignedOn: updateReferralDto.assignedOn
+        ? new Date(updateReferralDto.assignedOn)
+        : undefined,
+      firstContactMadeOn: updateReferralDto.firstContactMadeOn
+        ? new Date(updateReferralDto.firstContactMadeOn)
+        : undefined,
+      currentlyConnectedSupports: updateReferralDto.currentlyConnectedSupports,
+      currentlyConnectedSupportsOther:
+        updateReferralDto.currentlyConnectedSupportsOther,
+      regionId: updateReferralDto.regionId,
+      specificCityTown: updateReferralDto.specificCityTown,
+      neededSupports: updateReferralDto.neededSupports,
+      neededSupportsOther: updateReferralDto.neededSupportsOther,
+      referralSummary: updateReferralDto.referralSummary,
+      referredBy: updateReferralDto.referredBy,
+      ministryId: updateReferralDto.ministryId,
+      ministryNameOther: updateReferralDto.ministryNameOther,
+      agencyTypeId: updateReferralDto.agencyTypeId,
+      agencyTypeOther: updateReferralDto.agencyTypeOther,
+      partnerAgencyName: updateReferralDto.partnerAgencyName,
+      programArea: updateReferralDto.programArea,
+      referrerContactName: updateReferralDto.referrerContactName,
+      referrerEmail: updateReferralDto.referrerEmail,
+      referrerPhone: updateReferralDto.referrerPhone,
+      individualFirstName: updateReferralDto.individualFirstName,
+      individualMiddleName: updateReferralDto.individualMiddleName,
+      individualLastName: updateReferralDto.individualLastName,
+      individualPreferredName: updateReferralDto.individualPreferredName,
+      individualDateOfBirth: updateReferralDto.individualDateOfBirth
+        ? new Date(updateReferralDto.individualDateOfBirth)
+        : undefined,
+      individualPhone: updateReferralDto.individualPhone,
+      personId: updateReferralDto.personId,
+      secondaryContact: updateReferralDto.secondaryContact,
+      bestWayToReach: updateReferralDto.bestWayToReach,
+      currentlyHomeless: updateReferralDto.currentlyHomeless,
+      losingHousing: updateReferralDto.losingHousing,
+      pendingRelease: updateReferralDto.pendingRelease,
+      releaseDate: updateReferralDto.releaseDate
+        ? new Date(updateReferralDto.releaseDate)
+        : undefined,
+    };
+
+    // Remove undefined keys so diffObjects only sees provided fields
+    const cleanData: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(updateData)) {
+      if (value !== undefined) {
+        cleanData[key] = value;
+      }
+    }
+
+    const changes = diffObjects(
+      existing as unknown as Record<string, unknown>,
+      cleanData,
+      TRACKED_FIELDS,
+    );
+
+    const hasStatusChange = changes.some((c) => c.field === 'referralStatus');
+
+    const updated = await this.prisma.referral.update({
       where: { id },
-      data: {
-        referralStatus: updateReferralDto.referralStatus,
-        assignedToId: updateReferralDto.assignedToId,
-        referralOutcome: updateReferralDto.referralOutcome,
-        communityPartnerName: updateReferralDto.communityPartnerName,
-        flag: updateReferralDto.flag,
-        modifiedBy: userId,
-        followUpDate: updateReferralDto.followUpDate
-          ? new Date(updateReferralDto.followUpDate)
-          : undefined,
-        dueDate: updateReferralDto.dueDate
-          ? new Date(updateReferralDto.dueDate)
-          : undefined,
-        completedDate: updateReferralDto.completedDate
-          ? new Date(updateReferralDto.completedDate)
-          : undefined,
-      },
+      data: cleanData,
       include: {
         region: true,
         ministry: true,
@@ -197,5 +311,16 @@ export class ReferralsService {
         assignedTo: true,
       },
     });
+
+    if (changes.length > 0) {
+      await this.auditService.logReferralChange({
+        referralId: id,
+        action: hasStatusChange ? 'STATUS_CHANGE' : 'UPDATE',
+        changes,
+        userId,
+      });
+    }
+
+    return updated;
   }
 }

--- a/backend/src/regions/regions.controller.spec.ts
+++ b/backend/src/regions/regions.controller.spec.ts
@@ -15,6 +15,8 @@ const mockRegion = {
   name: 'Test Region',
 };
 
+const mockUser = { id: 'user-1' };
+
 describe('RegionsController', () => {
   let controller: RegionsController;
 
@@ -53,12 +55,18 @@ describe('RegionsController', () => {
     it('should delegate to service with dto', async () => {
       mockRegionsService.create.mockResolvedValue(mockRegion);
 
-      const result = await controller.create({ name: 'Test Region' } as any);
+      const result = await controller.create(
+        { name: 'Test Region' } as any,
+        mockUser as any,
+      );
 
       expect(result).toEqual(mockRegion);
-      expect(mockRegionsService.create).toHaveBeenCalledWith({
-        name: 'Test Region',
-      });
+      expect(mockRegionsService.create).toHaveBeenCalledWith(
+        {
+          name: 'Test Region',
+        },
+        'user-1',
+      );
     });
   });
 
@@ -67,14 +75,22 @@ describe('RegionsController', () => {
       const updated = { ...mockRegion, name: 'Updated Region' };
       mockRegionsService.update.mockResolvedValue(updated);
 
-      const result = await controller.update('region-1', {
-        name: 'Updated Region',
-      } as any);
+      const result = await controller.update(
+        'region-1',
+        {
+          name: 'Updated Region',
+        } as any,
+        mockUser as any,
+      );
 
       expect(result.name).toBe('Updated Region');
-      expect(mockRegionsService.update).toHaveBeenCalledWith('region-1', {
-        name: 'Updated Region',
-      });
+      expect(mockRegionsService.update).toHaveBeenCalledWith(
+        'region-1',
+        {
+          name: 'Updated Region',
+        },
+        'user-1',
+      );
     });
   });
 
@@ -82,9 +98,12 @@ describe('RegionsController', () => {
     it('should delegate to service with id', async () => {
       mockRegionsService.remove.mockResolvedValue(mockRegion);
 
-      await controller.remove('region-1');
+      await controller.remove('region-1', mockUser as any);
 
-      expect(mockRegionsService.remove).toHaveBeenCalledWith('region-1');
+      expect(mockRegionsService.remove).toHaveBeenCalledWith(
+        'region-1',
+        'user-1',
+      );
     });
   });
 });

--- a/backend/src/regions/regions.controller.ts
+++ b/backend/src/regions/regions.controller.ts
@@ -24,7 +24,8 @@ import { CreateRegionDto } from './dto/create-region.dto';
 import { UpdateRegionDto } from './dto/update-region.dto';
 import { Region, UserRole } from '../generated/prisma/client';
 import { AdminAuthGuard, RolesGuard } from '../auth/guards';
-import { Roles } from '../auth/decorators';
+import { Roles, CurrentUser } from '../auth/decorators';
+import type { User } from '../generated/prisma/client';
 
 @ApiTags('regions')
 @ApiBearerAuth()
@@ -71,8 +72,11 @@ export class RegionsController {
     status: 409,
     description: 'Region with this name already exists',
   })
-  async create(@Body() createRegionDto: CreateRegionDto): Promise<Region> {
-    return this.regionsService.create(createRegionDto);
+  async create(
+    @Body() createRegionDto: CreateRegionDto,
+    @CurrentUser() user: User,
+  ): Promise<Region> {
+    return this.regionsService.create(createRegionDto, user.id);
   }
 
   @Put(':id')
@@ -98,8 +102,9 @@ export class RegionsController {
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateRegionDto: UpdateRegionDto,
+    @CurrentUser() user: User,
   ): Promise<Region> {
-    return this.regionsService.update(id, updateRegionDto);
+    return this.regionsService.update(id, updateRegionDto, user.id);
   }
 
   @Delete(':id')
@@ -114,7 +119,10 @@ export class RegionsController {
     description: 'Forbidden - Insufficient permissions',
   })
   @ApiResponse({ status: 404, description: 'Region not found' })
-  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
-    await this.regionsService.remove(id);
+  async remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: User,
+  ): Promise<void> {
+    await this.regionsService.remove(id, user.id);
   }
 }

--- a/backend/src/regions/regions.module.ts
+++ b/backend/src/regions/regions.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { RegionsController } from './regions.controller';
 import { RegionsService } from './regions.service';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
+  imports: [AuditModule],
   controllers: [RegionsController],
   providers: [RegionsService],
   exports: [RegionsService],

--- a/backend/src/regions/regions.service.spec.ts
+++ b/backend/src/regions/regions.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException, ConflictException } from '@nestjs/common';
 import { RegionsService } from './regions.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 import { Prisma } from '../generated/prisma/client';
 
 const mockPrismaService = {
@@ -12,6 +13,10 @@ const mockPrismaService = {
     update: jest.fn(),
     delete: jest.fn(),
   },
+};
+
+const mockAuditService = {
+  logGlobal: jest.fn().mockResolvedValue(undefined),
 };
 
 const mockRegion = {
@@ -29,6 +34,7 @@ describe('RegionsService', () => {
       providers: [
         RegionsService,
         { provide: PrismaService, useValue: mockPrismaService },
+        { provide: AuditService, useValue: mockAuditService },
       ],
     }).compile();
 
@@ -71,11 +77,18 @@ describe('RegionsService', () => {
     it('should create and return a region', async () => {
       mockPrismaService.region.create.mockResolvedValue(mockRegion);
 
-      const result = await service.create({ name: 'Test Region' });
+      const result = await service.create({ name: 'Test Region' }, 'admin-1');
 
       expect(result).toEqual(mockRegion);
       expect(mockPrismaService.region.create).toHaveBeenCalledWith({
         data: { name: 'Test Region' },
+      });
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'region',
+        recordId: 'region-1',
+        action: 'CREATE',
+        changes: [{ field: 'name', oldValue: null, newValue: 'Test Region' }],
+        userId: 'admin-1',
       });
     });
 
@@ -108,11 +121,39 @@ describe('RegionsService', () => {
       mockPrismaService.region.findUnique.mockResolvedValue(mockRegion);
       mockPrismaService.region.update.mockResolvedValue(updated);
 
-      const result = await service.update('region-1', {
-        name: 'Updated Region',
-      });
+      const result = await service.update(
+        'region-1',
+        {
+          name: 'Updated Region',
+        },
+        'admin-1',
+      );
 
       expect(result.name).toBe('Updated Region');
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'region',
+        recordId: 'region-1',
+        action: 'UPDATE',
+        changes: [
+          {
+            field: 'name',
+            oldValue: 'Test Region',
+            newValue: 'Updated Region',
+          },
+        ],
+        userId: 'admin-1',
+      });
+    });
+
+    it('should not log audit when no fields changed', async () => {
+      mockPrismaService.region.findUnique.mockResolvedValue(mockRegion);
+      mockPrismaService.region.update.mockResolvedValue(mockRegion);
+
+      await service.update('region-1', {
+        name: 'Test Region',
+      });
+
+      expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException for nonexistent region', async () => {
@@ -142,11 +183,18 @@ describe('RegionsService', () => {
       mockPrismaService.region.findUnique.mockResolvedValue(mockRegion);
       mockPrismaService.region.delete.mockResolvedValue(mockRegion);
 
-      const result = await service.remove('region-1');
+      const result = await service.remove('region-1', 'admin-1');
 
       expect(result).toEqual(mockRegion);
       expect(mockPrismaService.region.delete).toHaveBeenCalledWith({
         where: { id: 'region-1' },
+      });
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'region',
+        recordId: 'region-1',
+        action: 'DELETE',
+        changes: [],
+        userId: 'admin-1',
       });
     });
 

--- a/backend/src/regions/regions.service.ts
+++ b/backend/src/regions/regions.service.ts
@@ -4,13 +4,26 @@ import {
   ConflictException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { diffObjects } from '../audit/audit.utils';
 import { Region, Prisma } from '../generated/prisma/client';
 import { CreateRegionDto } from './dto/create-region.dto';
 import { UpdateRegionDto } from './dto/update-region.dto';
 
+const TRACKED_FIELDS = [
+  'name',
+  'managerEmail',
+  'supervisorEmail',
+  'assistantSupervisorEmail',
+  'sharedMailboxEmail',
+];
+
 @Injectable()
 export class RegionsService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+  ) {}
 
   async findAll(): Promise<Region[]> {
     return this.prisma.region.findMany({
@@ -32,11 +45,24 @@ export class RegionsService {
     return region;
   }
 
-  async create(createRegionDto: CreateRegionDto): Promise<Region> {
+  async create(
+    createRegionDto: CreateRegionDto,
+    userId?: string,
+  ): Promise<Region> {
     try {
-      return await this.prisma.region.create({
+      const region = await this.prisma.region.create({
         data: createRegionDto,
       });
+
+      await this.auditService.logGlobal({
+        tableName: 'region',
+        recordId: region.id,
+        action: 'CREATE',
+        changes: [{ field: 'name', oldValue: null, newValue: region.name }],
+        userId,
+      });
+
+      return region;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (error.code === 'P2002') {
@@ -47,14 +73,36 @@ export class RegionsService {
     }
   }
 
-  async update(id: string, updateRegionDto: UpdateRegionDto): Promise<Region> {
-    await this.findOne(id);
+  async update(
+    id: string,
+    updateRegionDto: UpdateRegionDto,
+    userId?: string,
+  ): Promise<Region> {
+    const existing = await this.findOne(id);
+
+    const changes = diffObjects(
+      existing as unknown as Record<string, unknown>,
+      updateRegionDto as unknown as Record<string, unknown>,
+      TRACKED_FIELDS,
+    );
 
     try {
-      return await this.prisma.region.update({
+      const updated = await this.prisma.region.update({
         where: { id },
         data: updateRegionDto,
       });
+
+      if (changes.length > 0) {
+        await this.auditService.logGlobal({
+          tableName: 'region',
+          recordId: id,
+          action: 'UPDATE',
+          changes,
+          userId,
+        });
+      }
+
+      return updated;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (error.code === 'P2002') {
@@ -65,11 +113,21 @@ export class RegionsService {
     }
   }
 
-  async remove(id: string): Promise<Region> {
+  async remove(id: string, userId?: string): Promise<Region> {
     await this.findOne(id);
 
-    return this.prisma.region.delete({
+    const removed = await this.prisma.region.delete({
       where: { id },
     });
+
+    await this.auditService.logGlobal({
+      tableName: 'region',
+      recordId: id,
+      action: 'DELETE',
+      changes: [],
+      userId,
+    });
+
+    return removed;
   }
 }

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -31,15 +31,23 @@ describe('UsersController', () => {
     jest.clearAllMocks();
   });
 
+  describe('me', () => {
+    it('should return the current user', () => {
+      const result = controller.me(mockUser as any);
+
+      expect(result).toEqual(mockUser);
+    });
+  });
+
   describe('create', () => {
     it('should delegate to service', async () => {
       mockUsersService.create.mockResolvedValue(mockUser);
       const dto = { fullName: 'Test User', email: 'test@test.com' };
 
-      const result = await controller.create(dto as any);
+      const result = await controller.create(dto as any, mockUser as any);
 
       expect(result).toEqual(mockUser);
-      expect(mockUsersService.create).toHaveBeenCalledWith(dto);
+      expect(mockUsersService.create).toHaveBeenCalledWith(dto, 'user-1');
     });
   });
 
@@ -91,10 +99,18 @@ describe('UsersController', () => {
         fullName: 'Updated User',
       });
 
-      const result = await controller.update('user-1', dto as any);
+      const result = await controller.update(
+        'user-1',
+        dto as any,
+        mockUser as any,
+      );
 
       expect(result.fullName).toBe('Updated User');
-      expect(mockUsersService.update).toHaveBeenCalledWith('user-1', dto);
+      expect(mockUsersService.update).toHaveBeenCalledWith(
+        'user-1',
+        dto,
+        'user-1',
+      );
     });
   });
 
@@ -105,10 +121,10 @@ describe('UsersController', () => {
         isActive: false,
       });
 
-      const result = await controller.remove('user-1');
+      const result = await controller.remove('user-1', mockUser as any);
 
       expect(result.isActive).toBe(false);
-      expect(mockUsersService.remove).toHaveBeenCalledWith('user-1');
+      expect(mockUsersService.remove).toHaveBeenCalledWith('user-1', 'user-1');
     });
   });
 });

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -21,9 +21,10 @@ import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserDto, UserRole } from './dto/user.dto';
-import { User, UserRole as PrismaUserRole } from '../generated/prisma/client';
+import { UserRole as PrismaUserRole } from '../generated/prisma/client';
+import type { User } from '../generated/prisma/client';
 import { AdminAuthGuard, RolesGuard } from '../auth/guards';
-import { Roles } from '../auth/decorators';
+import { Roles, CurrentUser } from '../auth/decorators';
 
 @ApiTags('users')
 @ApiBearerAuth()
@@ -31,6 +32,18 @@ import { Roles } from '../auth/decorators';
 @UseGuards(AdminAuthGuard, RolesGuard)
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get current authenticated user' })
+  @ApiResponse({
+    status: 200,
+    description: 'Current user details',
+    type: UserDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  me(@CurrentUser() currentUser: User): User {
+    return currentUser;
+  }
 
   @Post()
   @Roles(PrismaUserRole.ADMIN, PrismaUserRole.SYSTEM_ADMINISTRATOR)
@@ -46,8 +59,11 @@ export class UsersController {
     status: 403,
     description: 'Forbidden - Insufficient permissions',
   })
-  async create(@Body() createUserDto: CreateUserDto): Promise<User> {
-    return this.usersService.create(createUserDto);
+  async create(
+    @Body() createUserDto: CreateUserDto,
+    @CurrentUser() currentUser: User,
+  ): Promise<User> {
+    return this.usersService.create(createUserDto, currentUser.id);
   }
 
   @Get()
@@ -104,8 +120,9 @@ export class UsersController {
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateUserDto: UpdateUserDto,
+    @CurrentUser() currentUser: User,
   ): Promise<User> {
-    return this.usersService.update(id, updateUserDto);
+    return this.usersService.update(id, updateUserDto, currentUser.id);
   }
 
   @Delete(':id')
@@ -118,7 +135,10 @@ export class UsersController {
     description: 'Forbidden - Insufficient permissions',
   })
   @ApiResponse({ status: 404, description: 'User not found' })
-  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<User> {
-    return this.usersService.remove(id);
+  async remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() currentUser: User,
+  ): Promise<User> {
+    return this.usersService.remove(id, currentUser.id);
   }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
+  imports: [AuditModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 
 const mockPrismaService = {
   user: {
@@ -10,6 +11,10 @@ const mockPrismaService = {
     findFirst: jest.fn(),
     update: jest.fn(),
   },
+};
+
+const mockAuditService = {
+  logGlobal: jest.fn().mockResolvedValue(undefined),
 };
 
 const mockUser = {
@@ -30,6 +35,7 @@ describe('UsersService', () => {
       providers: [
         UsersService,
         { provide: PrismaService, useValue: mockPrismaService },
+        { provide: AuditService, useValue: mockAuditService },
       ],
     }).compile();
 
@@ -46,7 +52,7 @@ describe('UsersService', () => {
       };
       mockPrismaService.user.create.mockResolvedValue(mockUser);
 
-      const result = await service.create(dto as any);
+      const result = await service.create(dto as any, 'admin-1');
 
       expect(result).toEqual(mockUser);
       expect(mockPrismaService.user.create).toHaveBeenCalledWith({
@@ -56,6 +62,17 @@ describe('UsersService', () => {
           role: 'ADMIN',
           isActive: true,
         },
+      });
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'user',
+        recordId: 'user-1',
+        action: 'CREATE',
+        changes: [
+          { field: 'fullName', oldValue: null, newValue: 'Test User' },
+          { field: 'email', oldValue: null, newValue: 'test@test.com' },
+          { field: 'role', oldValue: null, newValue: 'ADMIN' },
+        ],
+        userId: 'admin-1',
       });
     });
 
@@ -137,15 +154,43 @@ describe('UsersService', () => {
       mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
       mockPrismaService.user.update.mockResolvedValue(updated);
 
-      const result = await service.update('user-1', {
-        fullName: 'Updated User',
-      } as any);
+      const result = await service.update(
+        'user-1',
+        {
+          fullName: 'Updated User',
+        } as any,
+        'admin-1',
+      );
 
       expect(result.fullName).toBe('Updated User');
       expect(mockPrismaService.user.update).toHaveBeenCalledWith({
         where: { id: 'user-1' },
         data: { fullName: 'Updated User' },
       });
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'user',
+        recordId: 'user-1',
+        action: 'UPDATE',
+        changes: [
+          {
+            field: 'fullName',
+            oldValue: 'Test User',
+            newValue: 'Updated User',
+          },
+        ],
+        userId: 'admin-1',
+      });
+    });
+
+    it('should not log audit when no fields changed', async () => {
+      mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
+      mockPrismaService.user.update.mockResolvedValue(mockUser);
+
+      await service.update('user-1', {
+        fullName: 'Test User',
+      } as any);
+
+      expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException for nonexistent user', async () => {
@@ -163,7 +208,7 @@ describe('UsersService', () => {
       mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
       mockPrismaService.user.update.mockResolvedValue(deleted);
 
-      const result = await service.remove('user-1');
+      const result = await service.remove('user-1', 'admin-1');
 
       expect(result.isActive).toBe(false);
       expect(result.deletedAt).toBeDefined();
@@ -173,6 +218,13 @@ describe('UsersService', () => {
           deletedAt: expect.any(Date),
           isActive: false,
         },
+      });
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'user',
+        recordId: 'user-1',
+        action: 'DELETE',
+        changes: [],
+        userId: 'admin-1',
       });
     });
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -4,28 +4,49 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { diffObjects } from '../audit/audit.utils';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserRole } from './dto/user.dto';
 import { User } from '../generated/prisma/client';
 
+const TRACKED_FIELDS = ['fullName', 'email', 'role', 'isActive'];
+
 @Injectable()
 export class UsersService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+  ) {}
 
-  async create(createUserDto: CreateUserDto): Promise<User> {
+  async create(createUserDto: CreateUserDto, userId?: string): Promise<User> {
     if (!createUserDto.email) {
       throw new BadRequestException('Email is required');
     }
 
-    return this.prisma.user.create({
+    const user = await this.prisma.user.create({
       data: {
         fullName: createUserDto.fullName,
-        email: createUserDto.email,
+        email: createUserDto.email.toLowerCase(),
         role: createUserDto.role,
         isActive: true,
       },
     });
+
+    await this.auditService.logGlobal({
+      tableName: 'user',
+      recordId: user.id,
+      action: 'CREATE',
+      changes: [
+        { field: 'fullName', oldValue: null, newValue: user.fullName },
+        { field: 'email', oldValue: null, newValue: user.email },
+        { field: 'role', oldValue: null, newValue: user.role },
+      ],
+      userId,
+    });
+
+    return user;
   }
 
   async findAll(role?: UserRole, isActive?: boolean): Promise<User[]> {
@@ -56,24 +77,61 @@ export class UsersService {
     return user;
   }
 
-  async update(id: string, updateUserDto: UpdateUserDto): Promise<User> {
-    await this.findOne(id);
+  async update(
+    id: string,
+    updateUserDto: UpdateUserDto,
+    userId?: string,
+  ): Promise<User> {
+    const existing = await this.findOne(id);
 
-    return this.prisma.user.update({
+    const data = { ...updateUserDto };
+    if (data.email) {
+      data.email = data.email.toLowerCase();
+    }
+
+    const changes = diffObjects(
+      existing as unknown as Record<string, unknown>,
+      data as unknown as Record<string, unknown>,
+      TRACKED_FIELDS,
+    );
+
+    const updated = await this.prisma.user.update({
       where: { id },
-      data: updateUserDto,
+      data,
     });
+
+    if (changes.length > 0) {
+      await this.auditService.logGlobal({
+        tableName: 'user',
+        recordId: id,
+        action: 'UPDATE',
+        changes,
+        userId,
+      });
+    }
+
+    return updated;
   }
 
-  async remove(id: string): Promise<User> {
+  async remove(id: string, userId?: string): Promise<User> {
     await this.findOne(id);
 
-    return this.prisma.user.update({
+    const removed = await this.prisma.user.update({
       where: { id },
       data: {
         deletedAt: new Date(),
         isActive: false,
       },
     });
+
+    await this.auditService.logGlobal({
+      tableName: 'user',
+      recordId: id,
+      action: 'DELETE',
+      changes: [],
+      userId,
+    });
+
+    return removed;
   }
 }

--- a/referral-app/src/components/sections/IndividualInfoSection.tsx
+++ b/referral-app/src/components/sections/IndividualInfoSection.tsx
@@ -4,6 +4,7 @@ import {
   YesNoUnknown,
   YesNoUnknownOptions,
   ReleaseFromTypeOptions,
+  ReferredByType,
 } from "../../schemas/referralSchema";
 import {
   SelectField,
@@ -26,12 +27,14 @@ export function IndividualInfoSection({
 
   const currentlyHomeless = watch("currentlyHomeless");
   const pendingRelease = watch("pendingRelease");
+  const referredBy = watch("referredBy");
 
   // Only show losingHousing when currentlyHomeless is explicitly "NO" or "UNKNOWN"
   const showAtRiskField =
     currentlyHomeless === YesNoUnknown.NO ||
     currentlyHomeless === YesNoUnknown.UNKNOWN;
   const showReleaseDateField = !!pendingRelease;
+  const showGainFile = referredBy === ReferredByType.SDPR_INTERNAL;
 
   return (
     <section>
@@ -92,11 +95,13 @@ export function IndividualInfoSection({
           isRequired
         />
 
-        <TextInput
-          name="gainFile"
-          control={control}
-          label="GAIN File (SA) (Optional)"
-        />
+        {showGainFile && (
+          <TextInput
+            name="personId"
+            control={control}
+            label="GAIN File (Optional)"
+          />
+        )}
 
         <TextInput
           name="secondaryContact"

--- a/referral-app/src/components/sections/ReferralDetailsSection.tsx
+++ b/referral-app/src/components/sections/ReferralDetailsSection.tsx
@@ -24,7 +24,6 @@ export function ReferralDetailsSection({
 
   const showMinistryFields = referredBy === ReferredByType.PARTNER_MINISTRY;
   const showAgencyFields = referredBy === ReferredByType.PARTNER_AGENCY;
-  const showSDPRField = referredBy === ReferredByType.SDPR_INTERNAL;
 
   return (
     <section>
@@ -108,12 +107,6 @@ export function ReferralDetailsSection({
             control={control}
             label="Specify Agency Type (if not listed)"
           />
-        </div>
-      )}
-
-      {showSDPRField && (
-        <div className="form-grid">
-          <TextInput name="personId" control={control} label="Person ID" />
         </div>
       )}
     </section>

--- a/referral-app/src/schemas/referralSchema.ts
+++ b/referral-app/src/schemas/referralSchema.ts
@@ -145,9 +145,6 @@ const baseSchema = z.object({
   agencyTypeId: z.uuid().optional(),
   agencyTypeOther: z.string().optional(),
 
-  // SDPR Internal
-  personId: z.string().optional(),
-
   // Common referrer fields
   referrerContactName: z.string().min(1, "Contact name is required"),
   referrerEmail: z.email({ message: "Please enter a valid email" }),
@@ -158,7 +155,7 @@ const baseSchema = z.object({
   individualMiddleName: z.string().optional(),
   individualLastName: z.string().optional(),
   individualPreferredName: z.string().optional(),
-  gainFile: z.string().optional(),
+  personId: z.string().optional(),
   individualPhone: z.string().optional(),
   individualDateOfBirth: z.string().optional(),
   regionId: z.uuid({ message: "Please select a region" }),


### PR DESCRIPTION
Introduce full audit logging support and an admin Audit History UI, and replace the legacy referral.gainFile field with personId.

Backend: add Prisma models and migrations for audit_log and referral_audit_log, wire an AuditModule/service/utilities, add controller endpoints, and integrate audit logging into AgencyTypesService (create/update/delete) and app module. Update agency-types controller to accept the current user and pass userId to the service. Update tests to assert audit logging behavior.

Frontend: add AuditHistory page and AuditHistoryTab component (global and referral-scoped views), a useCurrentUser hook, API client methods (fetchAuditLogs, fetchReferralAuditHistory, fetchCurrentUser), and types for audit entries. Show Audit History nav/tab only to system administrators and invalidate referral-audit queries on referral updates.

Other: replace gainFile with personId across types and UI, add DB migration to drop referrals.gainFile, and update related tests and components.