### PR TITLE
Propagate 403 from admin auth; add AccessDenied UI

### DIFF
--- a/admin-app/index.html
+++ b/admin-app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>admin-app</title>
+    <title>CISB Referral App</title>
   </head>
   <body>
     <div id="root"></div>

--- a/admin-app/src/components/AccessDenied.tsx
+++ b/admin-app/src/components/AccessDenied.tsx
@@ -1,0 +1,33 @@
+import { Header, Footer } from "@bcgov/design-system-react-components";
+import { logout } from "../auth";
+
+export function AccessDenied() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header title="CISB Referral App" />
+      <main className="flex-1 bg-bcgov-gray-light flex items-center justify-center p-6">
+        <div className="max-w-md w-full bg-white rounded-lg border border-gray-200 shadow-sm p-6 text-center">
+          <h1 className="text-xl font-semibold text-bcgov-gray-dark mb-3">
+            Access denied
+          </h1>
+          <p className="text-bcgov-gray-dark mb-6">
+            Your account is not authorized. Please contact your administrator to
+            request access.
+          </p>
+          <button
+            type="button"
+            onClick={logout}
+            className="py-2 px-4 bg-bcgov-blue text-white rounded font-medium
+              hover:bg-bcgov-blue-dark focus:outline-none focus:ring-2
+              focus:ring-bcgov-blue transition-colors"
+          >
+            Logout
+          </button>
+        </div>
+      </main>
+      <div className="shrink-0">
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/admin-app/src/components/Layout.tsx
+++ b/admin-app/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet, NavLink } from "react-router-dom";
 import { Header, Footer } from "@bcgov/design-system-react-components";
 import { logout, getUser } from "../auth";
 import { useCurrentUser } from "../hooks";
+import { AccessDenied } from "./AccessDenied";
 
 /** Navigation links displayed in sidebar */
 const NAV_ITEMS = [
@@ -24,11 +25,15 @@ const SYSTEM_ADMIN_NAV_ITEMS = [
  */
 export function Layout() {
   const user = getUser();
-  const { isSystemAdmin } = useCurrentUser();
+  const { isSystemAdmin, isForbidden } = useCurrentUser();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const toggleSidebar = useCallback(() => setSidebarOpen((o) => !o), []);
   const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+
+  if (isForbidden) {
+    return <AccessDenied />;
+  }
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -60,7 +65,7 @@ export function Layout() {
           </svg>
         </button>
         <div className="flex-1">
-          <Header title="CISB Admin" />
+          <Header title="CISB Referral App" />
         </div>
       </div>
 

--- a/admin-app/src/components/index.ts
+++ b/admin-app/src/components/index.ts
@@ -1,3 +1,4 @@
 export { Layout } from "./Layout";
+export { AccessDenied } from "./AccessDenied";
 export * from "./ui";
 export * from "./referral";

--- a/admin-app/src/hooks/useCurrentUser.ts
+++ b/admin-app/src/hooks/useCurrentUser.ts
@@ -1,16 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
 import { apiService } from "../services/api";
 import type { User } from "../types";
 import { UserRole } from "../types";
 
 export function useCurrentUser() {
-  const { data: currentUser, isLoading } = useQuery<User>({
+  const { data: currentUser, isLoading, error } = useQuery<User>({
     queryKey: ["current-user"],
     queryFn: () => apiService.fetchCurrentUser(),
     staleTime: 5 * 60 * 1000,
+    retry: false,
   });
 
   const isSystemAdmin = currentUser?.role === UserRole.SYSTEM_ADMINISTRATOR;
+  const isForbidden =
+    axios.isAxiosError(error) && error.response?.status === 403;
 
-  return { currentUser, isLoading, isSystemAdmin };
+  return { currentUser, isLoading, isSystemAdmin, isForbidden };
 }

--- a/backend/src/auth/guards/either-auth.guard.spec.ts
+++ b/backend/src/auth/guards/either-auth.guard.spec.ts
@@ -1,4 +1,8 @@
-import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import {
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { EitherAuthGuard } from './either-auth.guard';
 
@@ -63,5 +67,18 @@ describe('EitherAuthGuard', () => {
     await expect(guard.canActivate(context)).rejects.toThrow(
       UnauthorizedException,
     );
+  });
+
+  it('should rethrow ForbiddenException from admin guard without falling through', async () => {
+    const context = createMockContext();
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+    const tryGuardSpy = jest
+      .spyOn(guard as any, 'tryGuard')
+      .mockRejectedValueOnce(new ForbiddenException('User not found.'));
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(tryGuardSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/auth/guards/either-auth.guard.ts
+++ b/backend/src/auth/guards/either-auth.guard.ts
@@ -1,7 +1,8 @@
 import {
-  Injectable,
   CanActivate,
   ExecutionContext,
+  ForbiddenException,
+  Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
@@ -43,8 +44,14 @@ export class EitherAuthGuard implements CanActivate {
       if (adminResult) {
         return true;
       }
-    } catch {
-      // Admin auth failed, try contact-jwt
+    } catch (error) {
+      // Admin JWT validated but the user is not permitted (not provisioned,
+      // deactivated, or deleted). Don't fall through to contact-jwt — rethrow
+      // so the client gets the specific 403 and can show the access-denied UI.
+      if (error instanceof ForbiddenException) {
+        throw error;
+      }
+      // Otherwise the token wasn't a valid admin token; fall through.
     }
 
     // Try contact-jwt
@@ -53,8 +60,10 @@ export class EitherAuthGuard implements CanActivate {
       if (contactResult) {
         return true;
       }
-    } catch {
-      // Contact auth also failed
+    } catch (error) {
+      if (error instanceof ForbiddenException) {
+        throw error;
+      }
     }
 
     throw new UnauthorizedException('Invalid or missing authentication token.');

--- a/backend/src/auth/strategies/admin-jwt.strategy.spec.ts
+++ b/backend/src/auth/strategies/admin-jwt.strategy.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException } from '@nestjs/common';
 import { AdminJwtStrategy } from './admin-jwt.strategy';
 import { KeycloakConfigService } from '../config';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -89,21 +89,21 @@ describe('AdminJwtStrategy', () => {
       });
     });
 
-    it('should throw UnauthorizedException when user not found', async () => {
+    it('should throw ForbiddenException when user not found', async () => {
       // Arrange
       const payload = createTestPayload({ sub: 'unknown-kc-id' });
       mockPrismaService.user.findUnique.mockResolvedValue(null);
 
       // Act & Assert
       await expect(strategy.validate(payload)).rejects.toThrow(
-        UnauthorizedException,
+        ForbiddenException,
       );
       await expect(strategy.validate(payload)).rejects.toThrow(
         'User not found. Please contact an administrator.',
       );
     });
 
-    it('should throw UnauthorizedException when user is inactive', async () => {
+    it('should throw ForbiddenException when user is inactive', async () => {
       // Arrange
       const inactiveUser = createTestUser({ isActive: false });
       const payload = createTestPayload();
@@ -111,14 +111,14 @@ describe('AdminJwtStrategy', () => {
 
       // Act & Assert
       await expect(strategy.validate(payload)).rejects.toThrow(
-        UnauthorizedException,
+        ForbiddenException,
       );
       await expect(strategy.validate(payload)).rejects.toThrow(
         'User account is deactivated.',
       );
     });
 
-    it('should throw UnauthorizedException when user is deleted', async () => {
+    it('should throw ForbiddenException when user is deleted', async () => {
       // Arrange
       const deletedUser = createTestUser({ deletedAt: new Date() });
       const payload = createTestPayload();
@@ -126,7 +126,7 @@ describe('AdminJwtStrategy', () => {
 
       // Act & Assert
       await expect(strategy.validate(payload)).rejects.toThrow(
-        UnauthorizedException,
+        ForbiddenException,
       );
       await expect(strategy.validate(payload)).rejects.toThrow(
         'User account has been deleted.',

--- a/backend/src/auth/strategies/admin-jwt.strategy.ts
+++ b/backend/src/auth/strategies/admin-jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy, ExtractJwt } from 'passport-jwt';
 import { passportJwtSecret } from 'jwks-rsa';
@@ -64,17 +64,17 @@ export class AdminJwtStrategy extends PassportStrategy(Strategy, 'admin-jwt') {
     }
 
     if (!user) {
-      throw new UnauthorizedException(
+      throw new ForbiddenException(
         'User not found. Please contact an administrator.',
       );
     }
 
     if (!user.isActive) {
-      throw new UnauthorizedException('User account is deactivated.');
+      throw new ForbiddenException('User account is deactivated.');
     }
 
     if (user.deletedAt) {
-      throw new UnauthorizedException('User account has been deleted.');
+      throw new ForbiddenException('User account has been deleted.');
     }
 
     return user;

--- a/referral-app/index.html
+++ b/referral-app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>referral-app</title>
+    <title>CISB Referral App</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Backend: change AdminJwtStrategy to throw ForbiddenException for missing, inactive or deleted users and update EitherAuthGuard to rethrow ForbiddenException so admin JWT failures that indicate lack of provisioning surface as 403 instead of falling through to contact-jwt. Tests updated to expect ForbiddenException.

Frontend: add an AccessDenied component and export it; use useCurrentUser to detect 403 responses (axios error check) and return isForbidden; Layout now renders the AccessDenied UI when isForbidden. Also update app titles to "CISB Referral App" in admin and referral index.html.