### PR TITLE
Add runtime config and CI image pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI & Build
 permissions:
   contents: read
-  packages: write
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
-name: CI
+name: CI & Build
 permissions:
   contents: read
+  packages: write
 
 on:
   pull_request:
@@ -11,6 +12,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   tests:
@@ -110,3 +115,80 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  build_and_push:
+    name: Build & push images
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for admin-app
+        id: meta-admin-app
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-app
+          tags: |
+            type=sha,prefix=sha-,format=long
+
+      - name: Build and push admin-app image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./admin-app
+          file: ./admin-app/Dockerfile
+          push: true
+          tags: ${{ steps.meta-admin-app.outputs.tags }}
+          labels: ${{ steps.meta-admin-app.outputs.labels }}
+
+      - name: Extract metadata for referral-app
+        id: meta-referral-app
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-referral-app
+          tags: |
+            type=sha,prefix=sha-,format=long
+
+      - name: Build and push referral-app image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./referral-app
+          file: ./referral-app/Dockerfile
+          push: true
+          tags: ${{ steps.meta-referral-app.outputs.tags }}
+          labels: ${{ steps.meta-referral-app.outputs.labels }}
+
+      - name: Extract metadata for backend
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend
+          tags: |
+            type=sha,prefix=sha-,format=long
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
+
+    outputs:
+      image_tag: sha-${{ github.sha }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Resolve image tag
         id: resolve

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,7 +1,9 @@
 name: Deploy to Dev
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI & Build"]
+    types: [completed]
     branches: [main]
 
 concurrency:
@@ -13,95 +15,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build_and_push:
-    runs-on: ubuntu-latest
-    environment:
-      name: dev
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata for admin-app
-        id: meta-admin-app
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-app
-          tags: |
-            type=sha,prefix=sha-,format=long
-            type=raw,value=dev
-
-      - name: Build and push admin-app image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./admin-app
-          file: ./admin-app/Dockerfile
-          push: true
-          tags: ${{ steps.meta-admin-app.outputs.tags }}
-          labels: ${{ steps.meta-admin-app.outputs.labels }}
-          build-args: |
-            VITE_KC_URL=${{ secrets.KC_URL }}
-            VITE_KC_REALM=${{ secrets.ADMIN_KC_REALM }}
-            VITE_KC_CLIENT_ID=${{ secrets.ADMIN_KC_CLIENT_ID }}
-
-      - name: Extract metadata for referral-app
-        id: meta-referral-app
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-referral-app
-          tags: |
-            type=sha,prefix=sha-,format=long
-            type=raw,value=dev
-
-      - name: Build and push referral-app image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./referral-app
-          file: ./referral-app/Dockerfile
-          push: true
-          tags: ${{ steps.meta-referral-app.outputs.tags }}
-          labels: ${{ steps.meta-referral-app.outputs.labels }}
-          build-args: |
-            VITE_KC_URL=${{ secrets.KC_URL }}
-            VITE_KC_REALM=${{ secrets.REFERRAL_KC_REALM }}
-            VITE_KC_CLIENT_ID=${{ secrets.REFERRAL_KC_CLIENT_ID }}
-
-      - name: Extract metadata for backend
-        id: meta-backend
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend
-          tags: |
-            type=sha,prefix=sha-,format=long
-            type=raw,value=dev
-
-      - name: Build and push backend image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          push: true
-          tags: ${{ steps.meta-backend.outputs.tags }}
-          labels: ${{ steps.meta-backend.outputs.labels }}
-
-    outputs:
-      image_tag: sha-${{ github.sha }}
-
   deploy:
-    needs: build_and_push
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: dev
@@ -111,6 +26,10 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: resolve
+        run: echo "tag=sha-${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -129,21 +48,25 @@ jobs:
           helm upgrade --install cisb-referral-admin-app ./helm/admin-app \
             --namespace ${{ secrets.OPENSHIFT_NAMESPACE }} \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-app \
-            --set image.tag=${{ needs.build_and_push.outputs.image_tag }} \
+            --set image.tag=${{ steps.resolve.outputs.tag }} \
             --set route.host=${{ secrets.ADMIN_APP_HOSTNAME }} \
-            --set config.KC_URL=${{ secrets.KC_URL }}
+            --set config.KC_URL=${{ secrets.KC_URL }} \
+            --set config.KC_REALM=${{ secrets.ADMIN_KC_REALM }} \
+            --set config.KC_CLIENT_ID=${{ secrets.ADMIN_KC_CLIENT_ID }}
 
           helm upgrade --install cisb-referral-referral-app ./helm/referral-app \
             --namespace ${{ secrets.OPENSHIFT_NAMESPACE }} \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-referral-app \
-            --set image.tag=${{ needs.build_and_push.outputs.image_tag }} \
+            --set image.tag=${{ steps.resolve.outputs.tag }} \
             --set route.host=${{ secrets.REFERRAL_APP_HOSTNAME }} \
-            --set config.KC_URL=${{ secrets.KC_URL }}
+            --set config.KC_URL=${{ secrets.KC_URL }} \
+            --set config.KC_REALM=${{ secrets.REFERRAL_KC_REALM }} \
+            --set config.KC_CLIENT_ID=${{ secrets.REFERRAL_KC_CLIENT_ID }}
 
           helm upgrade --install cisb-referral-backend ./helm/backend \
             --namespace ${{ secrets.OPENSHIFT_NAMESPACE }} \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend \
-            --set image.tag=${{ needs.build_and_push.outputs.image_tag }}
+            --set image.tag=${{ steps.resolve.outputs.tag }}
 
       - name: Trigger OpenShift Rollout
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,10 +14,9 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build_and_push:
+  retag:
+    name: Retag images for release
     runs-on: ubuntu-latest
-    environment:
-      name: production
     permissions:
       contents: read
       packages: write
@@ -26,8 +25,9 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Resolve image tag from commit SHA
+        id: resolve
+        run: echo "tag=sha-${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -36,70 +36,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for admin-app
-        id: meta-admin-app
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-app
-          tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
+      - name: Retag images with release version
+        run: |
+          for app in admin-app referral-app backend; do
+            src="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${app}:${{ steps.resolve.outputs.tag }}"
+            docker pull "$src"
+            docker tag "$src" "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${app}:${{ github.ref_name }}"
+            docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${app}:${{ github.ref_name }}"
+          done
 
-      - name: Build and push admin-app image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./admin-app
-          file: ./admin-app/Dockerfile
-          push: true
-          tags: ${{ steps.meta-admin-app.outputs.tags }}
-          labels: ${{ steps.meta-admin-app.outputs.labels }}
-          build-args: |
-            VITE_KC_URL=${{ secrets.KC_URL }}
-            VITE_KC_REALM=${{ secrets.ADMIN_KC_REALM }}
-            VITE_KC_CLIENT_ID=${{ secrets.ADMIN_KC_CLIENT_ID }}
-
-      - name: Extract metadata for referral-app
-        id: meta-referral-app
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-referral-app
-          tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-
-      - name: Build and push referral-app image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./referral-app
-          file: ./referral-app/Dockerfile
-          push: true
-          tags: ${{ steps.meta-referral-app.outputs.tags }}
-          labels: ${{ steps.meta-referral-app.outputs.labels }}
-          build-args: |
-            VITE_KC_URL=${{ secrets.KC_URL }}
-            VITE_KC_REALM=${{ secrets.REFERRAL_KC_REALM }}
-            VITE_KC_CLIENT_ID=${{ secrets.REFERRAL_KC_CLIENT_ID }}
-
-      - name: Extract metadata for backend
-        id: meta-backend
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend
-          tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-
-      - name: Build and push backend image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          push: true
-          tags: ${{ steps.meta-backend.outputs.tags }}
-          labels: ${{ steps.meta-backend.outputs.labels }}
+    outputs:
+      image_tag: ${{ github.ref_name }}
 
   deploy:
-    needs: build_and_push
+    needs: retag
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -127,9 +77,11 @@ jobs:
           helm upgrade --install cisb-referral-admin-app ./helm/admin-app \
             --namespace ${{ secrets.OPENSHIFT_NAMESPACE }} \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-app \
-            --set image.tag=${{ github.ref_name }} \
+            --set image.tag=${{ needs.retag.outputs.image_tag }} \
             --set route.host=${{ secrets.ADMIN_APP_HOSTNAME }} \
             --set config.KC_URL=${{ secrets.KC_URL }} \
+            --set config.KC_REALM=${{ secrets.ADMIN_KC_REALM }} \
+            --set config.KC_CLIENT_ID=${{ secrets.ADMIN_KC_CLIENT_ID }} \
             --set-string route.tls.certificate="${{ secrets.TLS_CERTIFICATE }}" \
             --set-string route.tls.key="${{ secrets.TLS_KEY }}" \
             --set-string route.tls.caCertificate="${{ secrets.TLS_CA_CERTIFICATE }}"
@@ -137,9 +89,11 @@ jobs:
           helm upgrade --install cisb-referral-referral-app ./helm/referral-app \
             --namespace ${{ secrets.OPENSHIFT_NAMESPACE }} \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-referral-app \
-            --set image.tag=${{ github.ref_name }} \
+            --set image.tag=${{ needs.retag.outputs.image_tag }} \
             --set route.host=${{ secrets.REFERRAL_APP_HOSTNAME }} \
             --set config.KC_URL=${{ secrets.KC_URL }} \
+            --set config.KC_REALM=${{ secrets.REFERRAL_KC_REALM }} \
+            --set config.KC_CLIENT_ID=${{ secrets.REFERRAL_KC_CLIENT_ID }} \
             --set-string route.tls.certificate="${{ secrets.TLS_CERTIFICATE }}" \
             --set-string route.tls.key="${{ secrets.TLS_KEY }}" \
             --set-string route.tls.caCertificate="${{ secrets.TLS_CA_CERTIFICATE }}"
@@ -147,7 +101,7 @@ jobs:
           helm upgrade --install cisb-referral-backend ./helm/backend \
             --namespace ${{ secrets.OPENSHIFT_NAMESPACE }} \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend \
-            --set image.tag=${{ github.ref_name }}
+            --set image.tag=${{ needs.retag.outputs.image_tag }}
 
       - name: Trigger OpenShift Rollout
         run: |

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -18,101 +18,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build_and_push:
-    runs-on: ubuntu-latest
-    environment:
-      name: test
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Resolve commit SHA
-        id: resolve
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata for admin-app
-        id: meta-admin-app
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-app
-          tags: |
-            type=raw,value=test-${{ steps.resolve.outputs.sha }}
-            type=raw,value=test
-
-      - name: Build and push admin-app image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./admin-app
-          file: ./admin-app/Dockerfile
-          push: true
-          tags: ${{ steps.meta-admin-app.outputs.tags }}
-          labels: ${{ steps.meta-admin-app.outputs.labels }}
-          build-args: |
-            VITE_KC_URL=${{ secrets.KC_URL }}
-            VITE_KC_REALM=${{ secrets.ADMIN_KC_REALM }}
-            VITE_KC_CLIENT_ID=${{ secrets.ADMIN_KC_CLIENT_ID }}
-
-      - name: Extract metadata for referral-app
-        id: meta-referral-app
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-referral-app
-          tags: |
-            type=raw,value=test-${{ steps.resolve.outputs.sha }}
-            type=raw,value=test
-
-      - name: Build and push referral-app image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./referral-app
-          file: ./referral-app/Dockerfile
-          push: true
-          tags: ${{ steps.meta-referral-app.outputs.tags }}
-          labels: ${{ steps.meta-referral-app.outputs.labels }}
-          build-args: |
-            VITE_KC_URL=${{ secrets.KC_URL }}
-            VITE_KC_REALM=${{ secrets.REFERRAL_KC_REALM }}
-            VITE_KC_CLIENT_ID=${{ secrets.REFERRAL_KC_CLIENT_ID }}
-
-      - name: Extract metadata for backend
-        id: meta-backend
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend
-          tags: |
-            type=raw,value=test-${{ steps.resolve.outputs.sha }}
-            type=raw,value=test
-
-      - name: Build and push backend image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          push: true
-          tags: ${{ steps.meta-backend.outputs.tags }}
-          labels: ${{ steps.meta-backend.outputs.labels }}
-
-    outputs:
-      image_tag: test-${{ steps.resolve.outputs.sha }}
-
   deploy:
-    needs: build_and_push
     runs-on: ubuntu-latest
     environment:
       name: test
@@ -124,6 +30,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Resolve image tag
+        id: resolve
+        run: echo "tag=sha-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -142,21 +52,25 @@ jobs:
           helm upgrade --install cisb-referral-admin-app ./helm/admin-app \
             --namespace ${{ secrets.OPENSHIFT_NAMESPACE }} \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-app \
-            --set image.tag=${{ needs.build_and_push.outputs.image_tag }} \
+            --set image.tag=${{ steps.resolve.outputs.tag }} \
             --set route.host=${{ secrets.ADMIN_APP_HOSTNAME }} \
-            --set config.KC_URL=${{ secrets.KC_URL }}
+            --set config.KC_URL=${{ secrets.KC_URL }} \
+            --set config.KC_REALM=${{ secrets.ADMIN_KC_REALM }} \
+            --set config.KC_CLIENT_ID=${{ secrets.ADMIN_KC_CLIENT_ID }}
 
           helm upgrade --install cisb-referral-referral-app ./helm/referral-app \
             --namespace ${{ secrets.OPENSHIFT_NAMESPACE }} \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-referral-app \
-            --set image.tag=${{ needs.build_and_push.outputs.image_tag }} \
+            --set image.tag=${{ steps.resolve.outputs.tag }} \
             --set route.host=${{ secrets.REFERRAL_APP_HOSTNAME }} \
-            --set config.KC_URL=${{ secrets.KC_URL }}
+            --set config.KC_URL=${{ secrets.KC_URL }} \
+            --set config.KC_REALM=${{ secrets.REFERRAL_KC_REALM }} \
+            --set config.KC_CLIENT_ID=${{ secrets.REFERRAL_KC_CLIENT_ID }}
 
           helm upgrade --install cisb-referral-backend ./helm/backend \
             --namespace ${{ secrets.OPENSHIFT_NAMESPACE }} \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend \
-            --set image.tag=${{ needs.build_and_push.outputs.image_tag }}
+            --set image.tag=${{ steps.resolve.outputs.tag }}
 
       - name: Trigger OpenShift Rollout
         run: |

--- a/admin-app/Dockerfile
+++ b/admin-app/Dockerfile
@@ -1,14 +1,6 @@
 FROM node:24-alpine AS build
 WORKDIR /app
 
-ARG VITE_KC_URL
-ARG VITE_KC_REALM
-ARG VITE_KC_CLIENT_ID
-
-ENV VITE_KC_URL=$VITE_KC_URL
-ENV VITE_KC_REALM=$VITE_KC_REALM
-ENV VITE_KC_CLIENT_ID=$VITE_KC_CLIENT_ID
-
 COPY package*.json ./
 RUN npm ci --prefer-offline --no-audit
 

--- a/admin-app/index.html
+++ b/admin-app/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/admin-app/src/auth/index.tsx
+++ b/admin-app/src/auth/index.tsx
@@ -1,10 +1,17 @@
 import { Suspense, use, type ReactNode } from "react";
 import Keycloak from "keycloak-js";
 
+const appConfig =
+  (
+    globalThis as typeof globalThis & {
+      __APP_CONFIG__?: Record<string, string>;
+    }
+  ).__APP_CONFIG__ ?? {};
+
 export const keycloak = new Keycloak({
-  url: import.meta.env.VITE_KC_URL,
-  realm: import.meta.env.VITE_KC_REALM,
-  clientId: import.meta.env.VITE_KC_CLIENT_ID,
+  url: appConfig.KC_URL ?? import.meta.env.VITE_KC_URL,
+  realm: appConfig.KC_REALM ?? import.meta.env.VITE_KC_REALM,
+  clientId: appConfig.KC_CLIENT_ID ?? import.meta.env.VITE_KC_CLIENT_ID,
 });
 
 export const init = async (): Promise<void> => {

--- a/helm/admin-app/templates/configmap.yaml
+++ b/helm/admin-app/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cisb-referral-admin-app-config
+  labels:
+    app.kubernetes.io/name: cisb-referral-admin-app
+data:
+  config.js: |
+    window.__APP_CONFIG__ = {
+      KC_URL: {{ .Values.config.KC_URL | quote }},
+      KC_REALM: {{ .Values.config.KC_REALM | quote }},
+      KC_CLIENT_ID: {{ .Values.config.KC_CLIENT_ID | quote }},
+    };

--- a/helm/admin-app/templates/deployment.yaml
+++ b/helm/admin-app/templates/deployment.yaml
@@ -41,6 +41,11 @@ spec:
               value: {{ .Values.config.BACKEND_URL | quote }}
             - name: KC_URL
               value: {{ .Values.config.KC_URL | quote }}
+          volumeMounts:
+            - name: app-config
+              mountPath: /srv/config.js
+              subPath: config.js
+              readOnly: true
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -75,4 +80,8 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
+      volumes:
+        - name: app-config
+          configMap:
+            name: cisb-referral-admin-app-config
       restartPolicy: Always

--- a/helm/admin-app/values.yaml
+++ b/helm/admin-app/values.yaml
@@ -41,3 +41,5 @@ affinity: {}
 config:
   BACKEND_URL: "http://cisb-referral-backend:80"
   KC_URL: ""
+  KC_REALM: ""
+  KC_CLIENT_ID: ""

--- a/helm/referral-app/templates/configmap.yaml
+++ b/helm/referral-app/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cisb-referral-referral-app-config
+  labels:
+    app.kubernetes.io/name: cisb-referral-referral-app
+data:
+  config.js: |
+    window.__APP_CONFIG__ = {
+      KC_URL: {{ .Values.config.KC_URL | quote }},
+      KC_REALM: {{ .Values.config.KC_REALM | quote }},
+      KC_CLIENT_ID: {{ .Values.config.KC_CLIENT_ID | quote }},
+    };

--- a/helm/referral-app/templates/deployment.yaml
+++ b/helm/referral-app/templates/deployment.yaml
@@ -41,6 +41,11 @@ spec:
               value: {{ .Values.config.BACKEND_URL | quote }}
             - name: KC_URL
               value: {{ .Values.config.KC_URL | quote }}
+          volumeMounts:
+            - name: app-config
+              mountPath: /srv/config.js
+              subPath: config.js
+              readOnly: true
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -75,4 +80,8 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
+      volumes:
+        - name: app-config
+          configMap:
+            name: cisb-referral-referral-app-config
       restartPolicy: Always

--- a/helm/referral-app/values.yaml
+++ b/helm/referral-app/values.yaml
@@ -40,3 +40,5 @@ affinity: {}
 config:
   BACKEND_URL: "http://cisb-referral-backend:80"
   KC_URL: ""
+  KC_REALM: ""
+  KC_CLIENT_ID: ""

--- a/referral-app/Dockerfile
+++ b/referral-app/Dockerfile
@@ -1,14 +1,6 @@
 FROM node:24-alpine AS build
 WORKDIR /app
 
-ARG VITE_KC_URL
-ARG VITE_KC_REALM
-ARG VITE_KC_CLIENT_ID
-
-ENV VITE_KC_URL=$VITE_KC_URL
-ENV VITE_KC_REALM=$VITE_KC_REALM
-ENV VITE_KC_CLIENT_ID=$VITE_KC_CLIENT_ID
-
 COPY package*.json ./
 RUN npm ci --prefer-offline --no-audit
 

--- a/referral-app/index.html
+++ b/referral-app/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/referral-app/src/auth/index.tsx
+++ b/referral-app/src/auth/index.tsx
@@ -1,10 +1,17 @@
 import { Suspense, use, type ReactNode } from "react";
 import Keycloak from "keycloak-js";
 
+const appConfig =
+  (
+    globalThis as typeof globalThis & {
+      __APP_CONFIG__?: Record<string, string>;
+    }
+  ).__APP_CONFIG__ ?? {};
+
 export const keycloak = new Keycloak({
-  url: import.meta.env.VITE_KC_URL,
-  realm: import.meta.env.VITE_KC_REALM,
-  clientId: import.meta.env.VITE_KC_CLIENT_ID,
+  url: appConfig.KC_URL ?? import.meta.env.VITE_KC_URL,
+  realm: appConfig.KC_REALM ?? import.meta.env.VITE_KC_REALM,
+  clientId: appConfig.KC_CLIENT_ID ?? import.meta.env.VITE_KC_CLIENT_ID,
 });
 
 export const init = async (): Promise<void> => {


### PR DESCRIPTION
Introduce runtime configuration via a generated config.js and move image build/push into the CI pipeline. Changes include:

- CI: rename workflow to "CI & Build", add REGISTRY/IMAGE_NAME env and a build_and_push job to build and push admin-app, referral-app and backend images on main (outputs image_tag).
- Deploy workflows: switch dev/test/prod to consume images produced by CI (use workflow_run or resolve/retag steps); production retags images to the release ref instead of rebuilding.
- Runtime config: index.html for both frontends now loads /config.js; Dockerfiles no longer bake VITE_* Keycloak args into the image.
- App code: auth modules updated to read window.__APP_CONFIG__ (fallback to VITE_ env) so Keycloak URL/realm/clientId are injected at runtime.
- Helm: add ConfigMap templates and mount config.js into admin and referral deployments; add KC_REALM and KC_CLIENT_ID values to charts.

Rationale: decouple build and deploy steps, avoid baking environment-specific Keycloak credentials into images, and allow environment-specific configuration to be injected at runtime via Helm-managed configmaps.