### PR TITLE
Add search filter to referrals list

### DIFF
--- a/admin-app/src/__tests__/services/api.service.test.ts
+++ b/admin-app/src/__tests__/services/api.service.test.ts
@@ -75,6 +75,26 @@ describe("APIService methods", () => {
       expect(result).toEqual(mockData);
     });
 
+    it("should fetch referrals with search param", async () => {
+      // Arrange
+      const mockData = { data: [{ id: "1" }], total: 1 };
+      mockGet.mockResolvedValue({ data: mockData });
+      const { apiService } = await import("../../services/api");
+
+      // Act
+      const result = await apiService.fetchReferrals({
+        page: 1,
+        limit: 25,
+        search: "Jane",
+      });
+
+      // Assert
+      expect(mockGet).toHaveBeenCalledWith("/referrals", {
+        params: { page: 1, limit: 25, search: "Jane" },
+      });
+      expect(result).toEqual(mockData);
+    });
+
     it("should fetch a single referral by id", async () => {
       // Arrange
       const mockReferral = { id: "abc-123" };

--- a/admin-app/src/pages/Referrals.tsx
+++ b/admin-app/src/pages/Referrals.tsx
@@ -26,12 +26,22 @@ export function Referrals() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [activeSearch, setActiveSearch] = useState("");
   const [pickerOpen, setPickerOpen] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ["referrals", { page, limit: PAGE_SIZE }],
-    queryFn: () => apiService.fetchReferrals({ page, limit: PAGE_SIZE }),
+    queryKey: [
+      "referrals",
+      { page, limit: PAGE_SIZE, search: activeSearch || undefined },
+    ],
+    queryFn: () =>
+      apiService.fetchReferrals({
+        page,
+        limit: PAGE_SIZE,
+        search: activeSearch || undefined,
+      }),
     placeholderData: keepPreviousData,
   });
 
@@ -105,6 +115,14 @@ export function Referrals() {
           <input
             type="text"
             placeholder="Filter by keyword"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                setActiveSearch(search.trim());
+                setPage(1);
+              }
+            }}
             className="py-2 px-3 border border-bcgov-border rounded text-sm
               w-full sm:w-50 focus:outline-none focus:border-bcgov-blue
               focus:ring-2 focus:ring-bcgov-blue/20"

--- a/admin-app/src/types/index.ts
+++ b/admin-app/src/types/index.ts
@@ -203,6 +203,7 @@ export interface FetchReferralsParams {
   limit?: number;
   status?: string;
   regionId?: string;
+  search?: string;
 }
 
 export const UserRole = {

--- a/backend/src/referrals/dto/find-all-referrals.dto.ts
+++ b/backend/src/referrals/dto/find-all-referrals.dto.ts
@@ -1,6 +1,16 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsEnum, IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
 import { ReferralStatus } from './update-referral.dto';
 
 export class FindAllReferralsDto {
@@ -33,4 +43,13 @@ export class FindAllReferralsDto {
   @IsOptional()
   @IsUUID()
   assignedToId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by referrer contact name (starts with)',
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  search?: string;
 }

--- a/backend/src/referrals/referrals.controller.spec.ts
+++ b/backend/src/referrals/referrals.controller.spec.ts
@@ -85,6 +85,16 @@ describe('ReferralsController', () => {
 
       expect(mockReferralsService.findAll).toHaveBeenCalledWith({});
     });
+
+    it('should pass the search param through to the service', async () => {
+      mockReferralsService.findAll.mockResolvedValue(mockPaginatedResult);
+
+      const query = { page: 1, limit: 10, search: 'Jane' };
+      const result = await controller.findAll(query);
+
+      expect(result).toEqual(mockPaginatedResult);
+      expect(mockReferralsService.findAll).toHaveBeenCalledWith(query);
+    });
   });
 
   describe('findOne', () => {

--- a/backend/src/referrals/referrals.controller.ts
+++ b/backend/src/referrals/referrals.controller.ts
@@ -83,6 +83,12 @@ export class ReferralsController {
     type: String,
     description: 'Filter by assigned user',
   })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description: 'Filter by referrer contact name (starts with)',
+  })
   @ApiResponse({ status: 200, description: 'List of referrals' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async findAll(@Query() query: FindAllReferralsDto) {

--- a/backend/src/referrals/referrals.service.spec.ts
+++ b/backend/src/referrals/referrals.service.spec.ts
@@ -506,6 +506,45 @@ describe('ReferralsService', () => {
         }),
       );
     });
+
+    it('should filter by referrerContactName startsWith when search is provided', async () => {
+      mockPrismaService.referral.findMany.mockResolvedValue([]);
+      mockPrismaService.referral.count.mockResolvedValue(0);
+
+      await service.findAll({ search: 'Jane' });
+
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            referrerContactName: { startsWith: 'Jane', mode: 'insensitive' },
+          },
+        }),
+      );
+      expect(mockPrismaService.referral.count).toHaveBeenCalledWith({
+        where: {
+          referrerContactName: { startsWith: 'Jane', mode: 'insensitive' },
+        },
+      });
+    });
+
+    it('should combine search with other filters', async () => {
+      mockPrismaService.referral.findMany.mockResolvedValue([]);
+      mockPrismaService.referral.count.mockResolvedValue(0);
+
+      await service.findAll({
+        status: ReferralStatus.OPEN,
+        search: 'Smith',
+      });
+
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            referralStatus: ReferralStatus.OPEN,
+            referrerContactName: { startsWith: 'Smith', mode: 'insensitive' },
+          },
+        }),
+      );
+    });
   });
 
   describe('findOne', () => {

--- a/backend/src/referrals/referrals.service.ts
+++ b/backend/src/referrals/referrals.service.ts
@@ -301,17 +301,31 @@ export class ReferralsService {
     status?: ReferralStatus;
     regionId?: string;
     assignedToId?: string;
+    search?: string;
   }): Promise<{
     data: Referral[];
     meta: { total: number; page: number; limit: number; totalPages: number };
   }> {
-    const { page = 1, limit = 10, status, regionId, assignedToId } = params;
+    const {
+      page = 1,
+      limit = 10,
+      status,
+      regionId,
+      assignedToId,
+      search,
+    } = params;
     const skip = (page - 1) * limit;
 
     const where = {
       ...(status && { referralStatus: status }),
       ...(regionId && { regionId }),
       ...(assignedToId && { assignedToId }),
+      ...(search && {
+        referrerContactName: {
+          startsWith: search,
+          mode: 'insensitive' as const,
+        },
+      }),
     };
 
     const [data, total] = await Promise.all([


### PR DESCRIPTION
Enable searching referrals by referrer contact name. Frontend: add search input and activeSearch state to Referrals page, include search in react-query key and api call (resets page on Enter), and update types; add api.service unit test to assert the search param is passed. Backend: accept optional `search` in FindAllReferralsDto (with min/max length and Swagger doc), document the query via ApiQuery on the controller, and apply a case-insensitive startsWith filter on referrerContactName in the service. Added controller and service tests to ensure the search param is forwarded and combined with other filters.