### PR TITLE
Reset active search and page when input cleared

### DIFF
--- a/admin-app/src/pages/Referrals.tsx
+++ b/admin-app/src/pages/Referrals.tsx
@@ -116,7 +116,14 @@ export function Referrals() {
             type="text"
             placeholder="Filter by keyword"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              const val = e.target.value;
+              setSearch(val);
+              if (!val.trim() && activeSearch) {
+                setActiveSearch("");
+                setPage(1);
+              }
+            }}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 setActiveSearch(search.trim());


### PR DESCRIPTION
Update the search input onChange handler to capture the value, update search state, and if the trimmed value becomes empty while an activeSearch exists, clear activeSearch and reset page to 1. This prevents a stale activeSearch from remaining after the user clears the input and ensures results return to the first page.