### PR TITLE
Enforce role-based user management rules

### DIFF
--- a/admin-app/src/__tests__/pages/AgencyTypes.test.tsx
+++ b/admin-app/src/__tests__/pages/AgencyTypes.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AgencyTypes } from "../../pages/AgencyTypes";
+import { UserRole } from "../../types";
+import type { AgencyType } from "../../types";
+
+const { mockUseCurrentUser, mockApiService } = vi.hoisted(() => ({
+  mockUseCurrentUser: vi.fn(),
+  mockApiService: {
+    fetchAgencyTypes: vi.fn(),
+  },
+}));
+
+vi.mock("../../hooks", () => ({
+  useCurrentUser: mockUseCurrentUser,
+}));
+
+vi.mock("../../services", () => ({
+  apiService: mockApiService,
+}));
+
+const testAgencyType: AgencyType = {
+  id: "agency-1",
+  name: "Non-Profit",
+  isActive: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function renderAgencyTypes() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgencyTypes />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AgencyTypes page RBAC", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiService.fetchAgencyTypes.mockResolvedValue([testAgencyType]);
+  });
+
+  it("hides add/edit/delete controls for USER role", async () => {
+    mockUseCurrentUser.mockReturnValue({
+      currentUser: { id: "user-1", role: UserRole.USER },
+      isLoading: false,
+    });
+
+    renderAgencyTypes();
+
+    expect(
+      screen.queryByRole("button", { name: "Add Agency Type" }),
+    ).not.toBeInTheDocument();
+
+    await screen.findByText("Non-Profit");
+
+    // EditableCell's Edit button should not be rendered
+    expect(
+      screen.queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument();
+    // Table's Delete button should not be rendered
+    expect(
+      screen.queryByRole("button", { name: "Delete" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([UserRole.ADMIN, UserRole.SYSTEM_ADMINISTRATOR])(
+    "shows add/edit/delete controls for %s role",
+    async (role) => {
+      mockUseCurrentUser.mockReturnValue({
+        currentUser: { id: "admin-1", role },
+        isLoading: false,
+      });
+
+      renderAgencyTypes();
+
+      expect(
+        screen.getByRole("button", { name: "Add Agency Type" }),
+      ).toBeInTheDocument();
+
+      await screen.findByText("Non-Profit");
+
+      expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Delete" }),
+      ).toBeInTheDocument();
+    },
+  );
+});

--- a/admin-app/src/__tests__/pages/Ministries.test.tsx
+++ b/admin-app/src/__tests__/pages/Ministries.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Ministries } from "../../pages/Ministries";
+import { UserRole } from "../../types";
+import type { Ministry } from "../../types";
+
+const { mockUseCurrentUser, mockApiService } = vi.hoisted(() => ({
+  mockUseCurrentUser: vi.fn(),
+  mockApiService: {
+    fetchMinistries: vi.fn(),
+  },
+}));
+
+vi.mock("../../hooks", () => ({
+  useCurrentUser: mockUseCurrentUser,
+}));
+
+vi.mock("../../services", () => ({
+  apiService: mockApiService,
+}));
+
+const testMinistry: Ministry = {
+  id: "ministry-1",
+  name: "Finance",
+  isActive: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function renderMinistries() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Ministries />
+    </QueryClientProvider>,
+  );
+}
+
+describe("Ministries page RBAC", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiService.fetchMinistries.mockResolvedValue([testMinistry]);
+  });
+
+  it("hides add/edit/delete controls for USER role", async () => {
+    mockUseCurrentUser.mockReturnValue({
+      currentUser: { id: "user-1", role: UserRole.USER },
+      isLoading: false,
+    });
+
+    renderMinistries();
+
+    expect(
+      screen.queryByRole("button", { name: "Add Ministry" }),
+    ).not.toBeInTheDocument();
+
+    await screen.findByText("Finance");
+
+    // EditableCell's Edit button should not be rendered
+    expect(
+      screen.queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument();
+    // Table's Delete button should not be rendered
+    expect(
+      screen.queryByRole("button", { name: "Delete" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([UserRole.ADMIN, UserRole.SYSTEM_ADMINISTRATOR])(
+    "shows add/edit/delete controls for %s role",
+    async (role) => {
+      mockUseCurrentUser.mockReturnValue({
+        currentUser: { id: "admin-1", role },
+        isLoading: false,
+      });
+
+      renderMinistries();
+
+      expect(
+        screen.getByRole("button", { name: "Add Ministry" }),
+      ).toBeInTheDocument();
+
+      await screen.findByText("Finance");
+
+      expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Delete" }),
+      ).toBeInTheDocument();
+    },
+  );
+});

--- a/admin-app/src/__tests__/pages/Regions.test.tsx
+++ b/admin-app/src/__tests__/pages/Regions.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Regions } from "../../pages/Regions";
+import { UserRole } from "../../types";
+import type { Region } from "../../types";
+
+const { mockUseCurrentUser, mockApiService } = vi.hoisted(() => ({
+  mockUseCurrentUser: vi.fn(),
+  mockApiService: {
+    fetchRegions: vi.fn(),
+  },
+}));
+
+vi.mock("../../hooks", () => ({
+  useCurrentUser: mockUseCurrentUser,
+}));
+
+vi.mock("../../services", () => ({
+  apiService: mockApiService,
+}));
+
+const testRegion: Region = {
+  id: "region-1",
+  name: "Vancouver Island",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function renderRegions() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Regions />
+    </QueryClientProvider>,
+  );
+}
+
+describe("Regions page RBAC", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiService.fetchRegions.mockResolvedValue([testRegion]);
+  });
+
+  it("hides add/edit/delete controls for USER role", async () => {
+    mockUseCurrentUser.mockReturnValue({
+      currentUser: { id: "user-1", role: UserRole.USER },
+      isLoading: false,
+    });
+
+    renderRegions();
+
+    expect(
+      screen.queryByRole("button", { name: "Add Region" }),
+    ).not.toBeInTheDocument();
+
+    await screen.findByText("Vancouver Island");
+
+    expect(
+      screen.queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([UserRole.ADMIN, UserRole.SYSTEM_ADMINISTRATOR])(
+    "shows add/edit/delete controls for %s role",
+    async (role) => {
+      mockUseCurrentUser.mockReturnValue({
+        currentUser: { id: "admin-1", role },
+        isLoading: false,
+      });
+
+      renderRegions();
+
+      expect(
+        screen.getByRole("button", { name: "Add Region" }),
+      ).toBeInTheDocument();
+
+      await screen.findByText("Vancouver Island");
+
+      expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Delete" }),
+      ).toBeInTheDocument();
+    },
+  );
+});

--- a/admin-app/src/__tests__/pages/Users.test.tsx
+++ b/admin-app/src/__tests__/pages/Users.test.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
@@ -117,5 +118,37 @@ describe("Users page RBAC", () => {
 
     const updatePayload = (mockApiService.updateUser as Mock).mock.calls[0][1];
     expect(updatePayload).not.toHaveProperty("role");
+  });
+
+  it("redirects USER role to /referrals instead of rendering the page", () => {
+    mockUseCurrentUser.mockReturnValue({
+      currentUser: buildUser({ role: UserRole.USER }),
+      isLoading: false,
+      isSystemAdmin: false,
+      isForbidden: false,
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <Users />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByRole("heading", { name: "Users" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add User" }),
+    ).not.toBeInTheDocument();
+    expect(mockApiService.fetchUsers).not.toHaveBeenCalled();
   });
 });

--- a/admin-app/src/__tests__/pages/Users.test.tsx
+++ b/admin-app/src/__tests__/pages/Users.test.tsx
@@ -1,0 +1,121 @@
+import { type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Users } from "../../pages/Users";
+import { UserRole, type User } from "../../types";
+
+const { mockUseCurrentUser, mockApiService } = vi.hoisted(() => ({
+  mockUseCurrentUser: vi.fn(),
+  mockApiService: {
+    fetchUsers: vi.fn(),
+    updateUser: vi.fn(),
+    createUser: vi.fn(),
+    deleteUser: vi.fn(),
+  },
+}));
+
+vi.mock("../../hooks", () => ({
+  useCurrentUser: mockUseCurrentUser,
+}));
+
+vi.mock("../../services", () => ({
+  apiService: mockApiService,
+}));
+
+vi.mock("../../components/ui", async () => {
+  const actual = await vi.importActual<typeof import("../../components/ui")>(
+    "../../components/ui",
+  );
+
+  return {
+    ...actual,
+    Dialog: ({
+      open,
+      title,
+      children,
+    }: {
+      open: boolean;
+      title: string;
+      children: ReactNode;
+    }) =>
+      open ? (
+        <dialog open aria-label={title}>
+          {children}
+        </dialog>
+      ) : null,
+  };
+});
+
+function buildUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "admin-1",
+    fullName: "Current Admin",
+    email: "admin@test.com",
+    role: UserRole.ADMIN,
+    isActive: true,
+    createdAt: "2026-05-14T00:00:00.000Z",
+    updatedAt: "2026-05-14T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderUsersPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Users />
+    </QueryClientProvider>,
+  );
+}
+
+describe("Users page RBAC", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseCurrentUser.mockReturnValue({
+      currentUser: buildUser(),
+      isLoading: false,
+      isSystemAdmin: false,
+      isForbidden: false,
+    });
+
+    mockApiService.fetchUsers.mockResolvedValue([buildUser()]);
+    mockApiService.updateUser.mockResolvedValue(buildUser());
+    mockApiService.createUser.mockResolvedValue(buildUser({ id: "user-2" }));
+    mockApiService.deleteUser.mockResolvedValue(buildUser({ isActive: false }));
+  });
+
+  it("locks role selection for self-edit and omits role in update payload", async () => {
+    renderUsersPage();
+
+    const editButton = await screen.findByRole("button", { name: "Edit" });
+    fireEvent.click(editButton);
+
+    const roleSelect = await screen.findByLabelText(/role/i);
+    expect(roleSelect).toBeDisabled();
+    expect(
+      screen.getByText("You cannot change your own role."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockApiService.updateUser).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockApiService.updateUser).toHaveBeenCalledWith("admin-1", {
+      fullName: "Current Admin",
+      email: "admin@test.com",
+    });
+
+    const updatePayload = (mockApiService.updateUser as Mock).mock.calls[0][1];
+    expect(updatePayload).not.toHaveProperty("role");
+  });
+});

--- a/admin-app/src/components/Layout.tsx
+++ b/admin-app/src/components/Layout.tsx
@@ -37,9 +37,9 @@ export function Layout() {
   }
 
   const navItems =
-    currentUser?.role === UserRole.USER
-      ? NAV_ITEMS
-      : [...NAV_ITEMS, USER_MANAGEMENT_NAV_ITEM];
+    currentUser && currentUser.role !== UserRole.USER
+      ? [...NAV_ITEMS, USER_MANAGEMENT_NAV_ITEM]
+      : NAV_ITEMS;
 
   return (
     <div className="flex flex-col min-h-screen">

--- a/admin-app/src/components/Layout.tsx
+++ b/admin-app/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet, NavLink } from "react-router-dom";
 import { Header, Footer } from "@bcgov/design-system-react-components";
 import { logout } from "../auth";
 import { useCurrentUser } from "../hooks";
+import { UserRole } from "../types";
 import { AccessDenied } from "./AccessDenied";
 
 /** Navigation links displayed in sidebar */
@@ -11,8 +12,9 @@ const NAV_ITEMS = [
   { to: "/regions", label: "Regions" },
   { to: "/ministries", label: "Ministries" },
   { to: "/agency-types", label: "Agency Types" },
-  { to: "/users", label: "Users" },
 ] as const;
+
+const USER_MANAGEMENT_NAV_ITEM = { to: "/users", label: "Users" } as const;
 
 const SYSTEM_ADMIN_NAV_ITEMS = [
   { to: "/audit-history", label: "Audit History" },
@@ -33,6 +35,11 @@ export function Layout() {
   if (isForbidden) {
     return <AccessDenied />;
   }
+
+  const navItems =
+    currentUser?.role === UserRole.USER
+      ? NAV_ITEMS
+      : [...NAV_ITEMS, USER_MANAGEMENT_NAV_ITEM];
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -79,7 +86,7 @@ export function Layout() {
           `}
         >
           <ul className="list-none m-0 p-0 flex-1">
-            {NAV_ITEMS.map((item) => (
+            {navItems.map((item) => (
               <li key={item.to}>
                 <NavLink
                   to={item.to}

--- a/admin-app/src/pages/AgencyTypes.tsx
+++ b/admin-app/src/pages/AgencyTypes.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Table, EditableCell } from "../components/ui";
+import { useCurrentUser } from "../hooks";
 import { apiService } from "../services";
 import type { AgencyType } from "../types";
+import { UserRole } from "../types";
 
 /**
  * Agency types management page with inline cell editing,
@@ -11,7 +13,11 @@ import type { AgencyType } from "../types";
  * @returns AgencyTypes admin page component
  */
 export function AgencyTypes() {
+  const { currentUser } = useCurrentUser();
   const queryClient = useQueryClient();
+  const canManage =
+    currentUser?.role === UserRole.ADMIN ||
+    currentUser?.role === UserRole.SYSTEM_ADMINISTRATOR;
   const [isAdding, setIsAdding] = useState(false);
   const [newName, setNewName] = useState("");
 
@@ -59,15 +65,18 @@ export function AgencyTypes() {
     {
       key: "name",
       header: "Name",
-      render: (agencyType: AgencyType) => (
-        <EditableCell
-          value={agencyType.name}
-          onSave={async (name) => {
-            if (!name) return;
-            await updateMutation.mutateAsync({ id: agencyType.id, name });
-          }}
-        />
-      ),
+      render: (agencyType: AgencyType) =>
+        canManage ? (
+          <EditableCell
+            value={agencyType.name}
+            onSave={async (name) => {
+              if (!name) return;
+              await updateMutation.mutateAsync({ id: agencyType.id, name });
+            }}
+          />
+        ) : (
+          <span className="px-2 py-1 inline-block">{agencyType.name}</span>
+        ),
     },
   ];
 
@@ -77,17 +86,19 @@ export function AgencyTypes() {
         <h1 className="text-xl font-bold text-bcgov-gray-dark m-0">
           Agency Types
         </h1>
-        <button
-          onClick={() => setIsAdding(true)}
-          disabled={isAdding}
-          className="px-4 py-2 bg-bcgov-blue text-white rounded
-            hover:bg-bcgov-blue-dark disabled:opacity-50 self-start sm:self-auto"
-        >
-          Add Agency Type
-        </button>
+        {canManage && (
+          <button
+            onClick={() => setIsAdding(true)}
+            disabled={isAdding}
+            className="px-4 py-2 bg-bcgov-blue text-white rounded
+              hover:bg-bcgov-blue-dark disabled:opacity-50 self-start sm:self-auto"
+          >
+            Add Agency Type
+          </button>
+        )}
       </div>
       <div className="p-4 sm:p-6">
-        {isAdding && (
+        {canManage && isAdding && (
           <div className="mb-4 flex flex-col sm:flex-row sm:items-center gap-3 p-4 bg-white border border-bcgov-border rounded">
             <input
               type="text"
@@ -127,7 +138,7 @@ export function AgencyTypes() {
         <Table
           data={agencyTypes}
           columns={columns}
-          onDelete={handleDelete}
+          onDelete={canManage ? handleDelete : undefined}
           loading={isLoading}
           emptyMessage="No agency types found"
         />

--- a/admin-app/src/pages/Ministries.tsx
+++ b/admin-app/src/pages/Ministries.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Table, EditableCell } from "../components/ui";
+import { useCurrentUser } from "../hooks";
 import { apiService } from "../services";
 import type { Ministry } from "../types";
+import { UserRole } from "../types";
 
 /**
  * Ministries management page with inline cell editing,
@@ -11,7 +13,11 @@ import type { Ministry } from "../types";
  * @returns Ministries admin page component
  */
 export function Ministries() {
+  const { currentUser } = useCurrentUser();
   const queryClient = useQueryClient();
+  const canManage =
+    currentUser?.role === UserRole.ADMIN ||
+    currentUser?.role === UserRole.SYSTEM_ADMINISTRATOR;
   const [isAdding, setIsAdding] = useState(false);
   const [newName, setNewName] = useState("");
 
@@ -59,15 +65,18 @@ export function Ministries() {
     {
       key: "name",
       header: "Name",
-      render: (ministry: Ministry) => (
-        <EditableCell
-          value={ministry.name}
-          onSave={async (name) => {
-            if (!name) return;
-            await updateMutation.mutateAsync({ id: ministry.id, name });
-          }}
-        />
-      ),
+      render: (ministry: Ministry) =>
+        canManage ? (
+          <EditableCell
+            value={ministry.name}
+            onSave={async (name) => {
+              if (!name) return;
+              await updateMutation.mutateAsync({ id: ministry.id, name });
+            }}
+          />
+        ) : (
+          <span className="px-2 py-1 inline-block">{ministry.name}</span>
+        ),
     },
   ];
 
@@ -77,17 +86,19 @@ export function Ministries() {
         <h1 className="text-xl font-bold text-bcgov-gray-dark m-0">
           Ministries
         </h1>
-        <button
-          onClick={() => setIsAdding(true)}
-          disabled={isAdding}
-          className="px-4 py-2 bg-bcgov-blue text-white rounded
-            hover:bg-bcgov-blue-dark disabled:opacity-50 self-start sm:self-auto"
-        >
-          Add Ministry
-        </button>
+        {canManage && (
+          <button
+            onClick={() => setIsAdding(true)}
+            disabled={isAdding}
+            className="px-4 py-2 bg-bcgov-blue text-white rounded
+              hover:bg-bcgov-blue-dark disabled:opacity-50 self-start sm:self-auto"
+          >
+            Add Ministry
+          </button>
+        )}
       </div>
       <div className="p-4 sm:p-6">
-        {isAdding && (
+        {canManage && isAdding && (
           <div className="mb-4 flex flex-col sm:flex-row sm:items-center gap-3 p-4 bg-white border border-bcgov-border rounded">
             <input
               type="text"
@@ -127,7 +138,7 @@ export function Ministries() {
         <Table
           data={ministries}
           columns={columns}
-          onDelete={handleDelete}
+          onDelete={canManage ? handleDelete : undefined}
           loading={isLoading}
           emptyMessage="No ministries found"
         />

--- a/admin-app/src/pages/Regions.tsx
+++ b/admin-app/src/pages/Regions.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Table } from "../components/ui";
+import { useCurrentUser } from "../hooks";
 import { apiService } from "../services";
 import type { Region, CreateRegionDto, UpdateRegionDto } from "../types";
+import { UserRole } from "../types";
 
 /** Fields that can be edited on a region row */
 type RegionEditValues = {
@@ -24,7 +26,11 @@ const INPUT_CLASS =
  * @returns Regions admin page component
  */
 export function Regions() {
+  const { currentUser } = useCurrentUser();
   const queryClient = useQueryClient();
+  const canManage =
+    currentUser?.role === UserRole.ADMIN ||
+    currentUser?.role === UserRole.SYSTEM_ADMINISTRATOR;
   const [isAdding, setIsAdding] = useState(false);
   const [newRegion, setNewRegion] = useState<CreateRegionDto>({
     name: "",
@@ -256,83 +262,89 @@ export function Regions() {
           </span>
         ),
     },
-    {
-      key: "actions",
-      header: "Actions",
-      render: (region: Region) =>
-        editingId === region.id ? (
-          <div className="flex flex-col gap-1">
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={handleSaveRow}
-                disabled={isSaving || !editValues.name.trim()}
-                className="px-3 py-1 text-sm font-medium text-white bg-bcgov-blue
+    ...(canManage
+      ? [
+          {
+            key: "actions",
+            header: "Actions",
+            render: (region: Region) =>
+              editingId === region.id ? (
+                <div className="flex flex-col gap-1">
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={handleSaveRow}
+                      disabled={isSaving || !editValues.name.trim()}
+                      className="px-3 py-1 text-sm font-medium text-white bg-bcgov-blue
                   rounded hover:bg-bcgov-blue-dark
                   transition-colors duration-150 disabled:opacity-50"
-              >
-                {isSaving ? "Saving..." : "Save"}
-              </button>
-              <button
-                type="button"
-                onClick={handleCancelEdit}
-                disabled={isSaving}
-                className="px-3 py-1 text-sm font-medium text-bcgov-gray-dark
+                    >
+                      {isSaving ? "Saving..." : "Save"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleCancelEdit}
+                      disabled={isSaving}
+                      className="px-3 py-1 text-sm font-medium text-bcgov-gray-dark
                   border border-bcgov-border rounded hover:bg-gray-100
                   transition-colors duration-150 disabled:opacity-50"
-              >
-                Cancel
-              </button>
-            </div>
-            {updateMutation.isError && (
-              <span className="text-red-600 text-sm">
-                Failed to save changes
-              </span>
-            )}
-          </div>
-        ) : (
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => handleEdit(region)}
-              className="px-3 py-1 text-sm font-medium text-bcgov-blue
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                  {updateMutation.isError && (
+                    <span className="text-red-600 text-sm">
+                      Failed to save changes
+                    </span>
+                  )}
+                </div>
+              ) : (
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleEdit(region)}
+                    className="px-3 py-1 text-sm font-medium text-bcgov-blue
                 border border-bcgov-border rounded hover:bg-blue-50
                 hover:border-bcgov-blue transition-colors duration-150"
-            >
-              Edit
-            </button>
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleDelete(region);
-              }}
-              className="px-3 py-1 text-sm font-medium text-red-600
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(region);
+                    }}
+                    className="px-3 py-1 text-sm font-medium text-red-600
                 border border-bcgov-border rounded hover:bg-red-50
                 hover:border-red-400 transition-colors duration-150"
-            >
-              Delete
-            </button>
-          </div>
-        ),
-    },
+                  >
+                    Delete
+                  </button>
+                </div>
+              ),
+          },
+        ]
+      : []),
   ];
 
   return (
     <div className="flex flex-col h-full">
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 p-4 px-4 sm:px-6 bg-white border-b border-bcgov-border">
         <h1 className="text-xl font-bold text-bcgov-gray-dark m-0">Regions</h1>
-        <button
-          onClick={() => setIsAdding(true)}
-          disabled={isAdding}
-          className="px-4 py-2 bg-bcgov-blue text-white rounded
-            hover:bg-bcgov-blue-dark disabled:opacity-50 self-start sm:self-auto"
-        >
-          Add Region
-        </button>
+        {canManage && (
+          <button
+            onClick={() => setIsAdding(true)}
+            disabled={isAdding}
+            className="px-4 py-2 bg-bcgov-blue text-white rounded
+              hover:bg-bcgov-blue-dark disabled:opacity-50 self-start sm:self-auto"
+          >
+            Add Region
+          </button>
+        )}
       </div>
       <div className="p-4 sm:p-6">
-        {isAdding && (
+        {canManage && isAdding && (
           <div className="mb-4 p-4 bg-white border border-bcgov-border rounded space-y-3">
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
               <input

--- a/admin-app/src/pages/Users.tsx
+++ b/admin-app/src/pages/Users.tsx
@@ -66,10 +66,11 @@ export function Users() {
       formData: CreateUserDto & Partial<UpdateUserDto>;
     }) => {
       if (data.editing) {
+        const isLocked = !assignableRoles.includes(data.editing.role);
         const updateData: UpdateUserDto = {
           fullName: data.formData.fullName,
           email: data.formData.email,
-          role: data.formData.role,
+          ...(isLocked ? {} : { role: data.formData.role }),
         };
         return apiService.updateUser(data.editing.id, updateData);
       }

--- a/admin-app/src/pages/Users.tsx
+++ b/admin-app/src/pages/Users.tsx
@@ -36,6 +36,7 @@ export function Users() {
     role: UserRole.USER,
   });
   const [error, setError] = useState<string | null>(null);
+  const isCurrentUserResolved = !isCurrentUserLoading;
 
   const assignableRoles =
     currentUser?.role === UserRole.SYSTEM_ADMINISTRATOR
@@ -43,12 +44,20 @@ export function Users() {
       : ADMIN_ASSIGNABLE_ROLES;
 
   const isUsersPageForbidden =
-    !isCurrentUserLoading && currentUser?.role === UserRole.USER;
+    isCurrentUserResolved &&
+    (!currentUser || currentUser.role === UserRole.USER);
+
+  const isRoleLocked =
+    editingUser != null && !assignableRoles.includes(editingUser.role);
+
+  const roleOptions = isRoleLocked
+    ? [editingUser.role, ...assignableRoles]
+    : assignableRoles;
 
   const { data: users = [], isLoading } = useQuery({
     queryKey: ["users"],
     queryFn: () => apiService.fetchUsers(),
-    enabled: !isUsersPageForbidden,
+    enabled: isCurrentUserResolved && !isUsersPageForbidden,
   });
 
   const saveMutation = useMutation({
@@ -195,6 +204,10 @@ export function Users() {
     },
   ];
 
+  if (!isCurrentUserResolved) {
+    return <div className="p-6 text-bcgov-gray-dark">Loading user...</div>;
+  }
+
   if (isUsersPageForbidden) {
     return <AccessDenied />;
   }
@@ -282,14 +295,24 @@ export function Users() {
                 setFormData({ ...formData, role: e.target.value as UserRole })
               }
               className="w-full px-3 py-2 border border-bcgov-border rounded focus:outline-none focus:ring-2 focus:ring-bcgov-blue"
+              disabled={isRoleLocked}
               required
             >
-              {assignableRoles.map((value) => (
-                <option key={value} value={value}>
+              {roleOptions.map((value) => (
+                <option
+                  key={value}
+                  value={value}
+                  disabled={isRoleLocked && editingUser?.role === value}
+                >
                   {USER_ROLE_LABELS[value]}
                 </option>
               ))}
             </select>
+            {isRoleLocked && (
+              <p className="mt-1 text-xs text-bcgov-gray-dark">
+                You cannot change the role for this user.
+              </p>
+            )}
           </div>
           <div className="flex justify-end gap-3 pt-4">
             <button

--- a/admin-app/src/pages/Users.tsx
+++ b/admin-app/src/pages/Users.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { AccessDenied } from "../components";
 import { Table, Dialog } from "../components/ui";
+import { useCurrentUser } from "../hooks";
 import { apiService } from "../services";
 import type { User, CreateUserDto, UpdateUserDto } from "../types";
 import { UserRole } from "../types";
@@ -11,7 +13,16 @@ const USER_ROLE_LABELS: Record<UserRole, string> = {
   [UserRole.SYSTEM_ADMINISTRATOR]: "System Administrator",
 };
 
+const ADMIN_ASSIGNABLE_ROLES: UserRole[] = [UserRole.USER, UserRole.ADMIN];
+
+const SYSTEM_ADMIN_ASSIGNABLE_ROLES: UserRole[] = [
+  UserRole.USER,
+  UserRole.ADMIN,
+  UserRole.SYSTEM_ADMINISTRATOR,
+];
+
 export function Users() {
+  const { currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -26,9 +37,18 @@ export function Users() {
   });
   const [error, setError] = useState<string | null>(null);
 
+  const assignableRoles =
+    currentUser?.role === UserRole.SYSTEM_ADMINISTRATOR
+      ? SYSTEM_ADMIN_ASSIGNABLE_ROLES
+      : ADMIN_ASSIGNABLE_ROLES;
+
+  const isUsersPageForbidden =
+    !isCurrentUserLoading && currentUser?.role === UserRole.USER;
+
   const { data: users = [], isLoading } = useQuery({
     queryKey: ["users"],
     queryFn: () => apiService.fetchUsers(),
+    enabled: !isUsersPageForbidden,
   });
 
   const saveMutation = useMutation({
@@ -79,7 +99,7 @@ export function Users() {
     setFormData({
       fullName: "",
       email: "",
-      role: UserRole.USER,
+      role: assignableRoles[0],
     });
     setError(null);
     setDialogOpen(true);
@@ -175,6 +195,10 @@ export function Users() {
     },
   ];
 
+  if (isUsersPageForbidden) {
+    return <AccessDenied />;
+  }
+
   return (
     <div className="flex flex-col h-full">
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 p-4 px-4 sm:px-6 bg-white border-b border-bcgov-border">
@@ -260,9 +284,9 @@ export function Users() {
               className="w-full px-3 py-2 border border-bcgov-border rounded focus:outline-none focus:ring-2 focus:ring-bcgov-blue"
               required
             >
-              {Object.entries(USER_ROLE_LABELS).map(([value, label]) => (
+              {assignableRoles.map((value) => (
                 <option key={value} value={value}>
-                  {label}
+                  {USER_ROLE_LABELS[value]}
                 </option>
               ))}
             </select>

--- a/admin-app/src/pages/Users.tsx
+++ b/admin-app/src/pages/Users.tsx
@@ -47,10 +47,16 @@ export function Users() {
     isCurrentUserResolved &&
     (!currentUser || currentUser.role === UserRole.USER);
 
-  const isRoleLocked =
+  const isEditingSelf =
+    editingUser != null && editingUser.id === currentUser?.id;
+
+  const isEditingRestrictedRole =
     editingUser != null && !assignableRoles.includes(editingUser.role);
 
-  const roleOptions = isRoleLocked
+  const isRoleLocked =
+    editingUser != null && (isEditingSelf || isEditingRestrictedRole);
+
+  const roleOptions = isEditingRestrictedRole
     ? [editingUser.role, ...assignableRoles]
     : assignableRoles;
 
@@ -66,7 +72,12 @@ export function Users() {
       formData: CreateUserDto & Partial<UpdateUserDto>;
     }) => {
       if (data.editing) {
-        const isLocked = !assignableRoles.includes(data.editing.role);
+        const isSelfEdit = data.editing.id === currentUser?.id;
+        const isEditingOutsideAssignableRoles = !assignableRoles.includes(
+          data.editing.role,
+        );
+        const isLocked = isSelfEdit || isEditingOutsideAssignableRoles;
+
         const updateData: UpdateUserDto = {
           fullName: data.formData.fullName,
           email: data.formData.email,
@@ -300,18 +311,16 @@ export function Users() {
               required
             >
               {roleOptions.map((value) => (
-                <option
-                  key={value}
-                  value={value}
-                  disabled={isRoleLocked && editingUser?.role === value}
-                >
+                <option key={value} value={value}>
                   {USER_ROLE_LABELS[value]}
                 </option>
               ))}
             </select>
             {isRoleLocked && (
               <p className="mt-1 text-xs text-bcgov-gray-dark">
-                You cannot change the role for this user.
+                {isEditingSelf
+                  ? "You cannot change your own role."
+                  : "You cannot change the role for this user."}
               </p>
             )}
           </div>

--- a/admin-app/src/pages/Users.tsx
+++ b/admin-app/src/pages/Users.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
+import { Navigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { AccessDenied } from "../components";
 import { Table, Dialog } from "../components/ui";
 import { useCurrentUser } from "../hooks";
 import { apiService } from "../services";
@@ -20,6 +20,12 @@ const SYSTEM_ADMIN_ASSIGNABLE_ROLES: UserRole[] = [
   UserRole.ADMIN,
   UserRole.SYSTEM_ADMINISTRATOR,
 ];
+
+type RoleEditState = {
+  isEditingSelf: boolean;
+  isEditingRestrictedRole: boolean;
+  isRoleLocked: boolean;
+};
 
 export function Users() {
   const { currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
@@ -50,18 +56,32 @@ export function Users() {
     isCurrentUserResolved &&
     (!currentUser || currentUser.role === UserRole.USER);
 
-  const isEditingSelf =
-    editingUser != null && editingUser.id === currentUser?.id;
+  const getRoleEditState = (editing: User | null): RoleEditState => {
+    if (!editing) {
+      return {
+        isEditingSelf: false,
+        isEditingRestrictedRole: false,
+        isRoleLocked: false,
+      };
+    }
 
-  const isEditingRestrictedRole =
-    editingUser != null && !assignableRoles.includes(editingUser.role);
+    const isEditingSelf = editing.id === currentUser?.id;
+    const isEditingRestrictedRole = !assignableRoles.includes(editing.role);
 
-  const isRoleLocked =
-    editingUser != null && (isEditingSelf || isEditingRestrictedRole);
+    return {
+      isEditingSelf,
+      isEditingRestrictedRole,
+      isRoleLocked: isEditingSelf || isEditingRestrictedRole,
+    };
+  };
 
-  const roleOptions = isEditingRestrictedRole
-    ? [editingUser.role, ...assignableRoles]
-    : assignableRoles;
+  const { isEditingSelf, isEditingRestrictedRole, isRoleLocked } =
+    getRoleEditState(editingUser);
+
+  const roleOptions =
+    isEditingRestrictedRole && editingUser != null
+      ? [editingUser.role, ...assignableRoles]
+      : assignableRoles;
 
   const { data: users = [], isLoading } = useQuery({
     queryKey: ["users"],
@@ -75,16 +95,12 @@ export function Users() {
       formData: CreateUserDto & Partial<UpdateUserDto>;
     }) => {
       if (data.editing) {
-        const isSelfEdit = data.editing.id === currentUser?.id;
-        const isEditingOutsideAssignableRoles = !assignableRoles.includes(
-          data.editing.role,
-        );
-        const isLocked = isSelfEdit || isEditingOutsideAssignableRoles;
+        const { isRoleLocked } = getRoleEditState(data.editing);
 
         const updateData: UpdateUserDto = {
           fullName: data.formData.fullName,
           email: data.formData.email,
-          ...(isLocked ? {} : { role: data.formData.role }),
+          ...(isRoleLocked ? {} : { role: data.formData.role }),
         };
         return apiService.updateUser(data.editing.id, updateData);
       }
@@ -224,7 +240,7 @@ export function Users() {
   }
 
   if (isUsersPageForbidden) {
-    return <AccessDenied />;
+    return <Navigate to="/referrals" replace />;
   }
 
   return (

--- a/admin-app/src/pages/Users.tsx
+++ b/admin-app/src/pages/Users.tsx
@@ -38,10 +38,13 @@ export function Users() {
   const [error, setError] = useState<string | null>(null);
   const isCurrentUserResolved = !isCurrentUserLoading;
 
-  const assignableRoles =
-    currentUser?.role === UserRole.SYSTEM_ADMINISTRATOR
-      ? SYSTEM_ADMIN_ASSIGNABLE_ROLES
-      : ADMIN_ASSIGNABLE_ROLES;
+  let assignableRoles: UserRole[] = [];
+
+  if (currentUser?.role === UserRole.SYSTEM_ADMINISTRATOR) {
+    assignableRoles = SYSTEM_ADMIN_ASSIGNABLE_ROLES;
+  } else if (currentUser?.role === UserRole.ADMIN) {
+    assignableRoles = ADMIN_ASSIGNABLE_ROLES;
+  }
 
   const isUsersPageForbidden =
     isCurrentUserResolved &&
@@ -120,7 +123,7 @@ export function Users() {
     setFormData({
       fullName: "",
       email: "",
-      role: assignableRoles[0],
+      role: assignableRoles[0] ?? UserRole.USER,
     });
     setError(null);
     setDialogOpen(true);

--- a/backend/src/users/dto/user.dto.ts
+++ b/backend/src/users/dto/user.dto.ts
@@ -9,12 +9,7 @@ import {
   IsDate,
   MaxLength,
 } from 'class-validator';
-
-export enum UserRole {
-  USER = 'USER',
-  ADMIN = 'ADMIN',
-  SYSTEM_ADMINISTRATOR = 'SYSTEM_ADMINISTRATOR',
-}
+import { UserRole } from '../../generated/prisma/client';
 
 export class UserDto {
   @ApiProperty()

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
+import { UserRole } from '../generated/prisma/client';
 
 const mockUsersService = {
   create: jest.fn(),
@@ -14,7 +15,7 @@ const mockUser = {
   id: 'user-1',
   fullName: 'Test User',
   email: 'test@test.com',
-  role: 'ADMIN',
+  role: UserRole.ADMIN,
   isActive: true,
 };
 
@@ -22,13 +23,13 @@ const mockCurrentUser = {
   id: 'admin-1',
   fullName: 'Current Admin',
   email: 'admin@test.com',
-  role: 'ADMIN',
+  role: UserRole.ADMIN,
   isActive: true,
 };
 
 const mockCurrentUserContext = {
   id: 'admin-1',
-  role: 'ADMIN',
+  role: UserRole.ADMIN,
 };
 
 describe('UsersController', () => {
@@ -74,12 +75,16 @@ describe('UsersController', () => {
     it('should parse isActive true string to boolean', async () => {
       mockUsersService.findAll.mockResolvedValue([mockUser]);
 
-      await controller.findAll('ADMIN' as any, 'true', mockCurrentUser as any);
+      await controller.findAll(
+        UserRole.ADMIN as any,
+        'true',
+        mockCurrentUser as any,
+      );
 
       expect(mockUsersService.findAll).toHaveBeenCalledWith(
-        'ADMIN',
+        UserRole.ADMIN,
         true,
-        'ADMIN',
+        UserRole.ADMIN,
       );
     });
 
@@ -91,7 +96,7 @@ describe('UsersController', () => {
       expect(mockUsersService.findAll).toHaveBeenCalledWith(
         undefined,
         false,
-        'ADMIN',
+        UserRole.ADMIN,
       );
     });
 
@@ -103,7 +108,7 @@ describe('UsersController', () => {
       expect(mockUsersService.findAll).toHaveBeenCalledWith(
         undefined,
         undefined,
-        'ADMIN',
+        UserRole.ADMIN,
       );
     });
   });

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -133,7 +133,7 @@ describe('UsersController', () => {
       const result = await controller.remove('user-1', mockUser as any);
 
       expect(result.isActive).toBe(false);
-      expect(mockUsersService.remove).toHaveBeenCalledWith('user-1', 'user-1');
+      expect(mockUsersService.remove).toHaveBeenCalledWith('user-1', mockUser);
     });
   });
 });

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -47,7 +47,7 @@ describe('UsersController', () => {
       const result = await controller.create(dto as any, mockUser as any);
 
       expect(result).toEqual(mockUser);
-      expect(mockUsersService.create).toHaveBeenCalledWith(dto, 'user-1');
+      expect(mockUsersService.create).toHaveBeenCalledWith(dto, mockUser);
     });
   });
 
@@ -55,27 +55,36 @@ describe('UsersController', () => {
     it('should parse isActive true string to boolean', async () => {
       mockUsersService.findAll.mockResolvedValue([mockUser]);
 
-      await controller.findAll('ADMIN' as any, 'true');
+      await controller.findAll('ADMIN' as any, 'true', mockUser as any);
 
-      expect(mockUsersService.findAll).toHaveBeenCalledWith('ADMIN', true);
+      expect(mockUsersService.findAll).toHaveBeenCalledWith(
+        'ADMIN',
+        true,
+        'ADMIN',
+      );
     });
 
     it('should parse isActive false string to boolean', async () => {
       mockUsersService.findAll.mockResolvedValue([]);
 
-      await controller.findAll(undefined, 'false');
+      await controller.findAll(undefined, 'false', mockUser as any);
 
-      expect(mockUsersService.findAll).toHaveBeenCalledWith(undefined, false);
+      expect(mockUsersService.findAll).toHaveBeenCalledWith(
+        undefined,
+        false,
+        'ADMIN',
+      );
     });
 
     it('should pass undefined when isActive not provided', async () => {
       mockUsersService.findAll.mockResolvedValue([mockUser]);
 
-      await controller.findAll();
+      await controller.findAll(undefined, undefined, mockUser as any);
 
       expect(mockUsersService.findAll).toHaveBeenCalledWith(
         undefined,
         undefined,
+        'ADMIN',
       );
     });
   });
@@ -109,7 +118,7 @@ describe('UsersController', () => {
       expect(mockUsersService.update).toHaveBeenCalledWith(
         'user-1',
         dto,
-        'user-1',
+        mockUser,
       );
     });
   });

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -18,6 +18,19 @@ const mockUser = {
   isActive: true,
 };
 
+const mockCurrentUser = {
+  id: 'admin-1',
+  fullName: 'Current Admin',
+  email: 'admin@test.com',
+  role: 'ADMIN',
+  isActive: true,
+};
+
+const mockCurrentUserContext = {
+  id: 'admin-1',
+  role: 'ADMIN',
+};
+
 describe('UsersController', () => {
   let controller: UsersController;
 
@@ -33,9 +46,9 @@ describe('UsersController', () => {
 
   describe('me', () => {
     it('should return the current user', () => {
-      const result = controller.me(mockUser as any);
+      const result = controller.me(mockCurrentUser as any);
 
-      expect(result).toEqual(mockUser);
+      expect(result).toEqual(mockCurrentUser);
     });
   });
 
@@ -44,10 +57,16 @@ describe('UsersController', () => {
       mockUsersService.create.mockResolvedValue(mockUser);
       const dto = { fullName: 'Test User', email: 'test@test.com' };
 
-      const result = await controller.create(dto as any, mockUser as any);
+      const result = await controller.create(
+        dto as any,
+        mockCurrentUser as any,
+      );
 
       expect(result).toEqual(mockUser);
-      expect(mockUsersService.create).toHaveBeenCalledWith(dto, mockUser);
+      expect(mockUsersService.create).toHaveBeenCalledWith(
+        dto,
+        mockCurrentUserContext,
+      );
     });
   });
 
@@ -55,7 +74,7 @@ describe('UsersController', () => {
     it('should parse isActive true string to boolean', async () => {
       mockUsersService.findAll.mockResolvedValue([mockUser]);
 
-      await controller.findAll('ADMIN' as any, 'true', mockUser as any);
+      await controller.findAll('ADMIN' as any, 'true', mockCurrentUser as any);
 
       expect(mockUsersService.findAll).toHaveBeenCalledWith(
         'ADMIN',
@@ -67,7 +86,7 @@ describe('UsersController', () => {
     it('should parse isActive false string to boolean', async () => {
       mockUsersService.findAll.mockResolvedValue([]);
 
-      await controller.findAll(undefined, 'false', mockUser as any);
+      await controller.findAll(undefined, 'false', mockCurrentUser as any);
 
       expect(mockUsersService.findAll).toHaveBeenCalledWith(
         undefined,
@@ -79,7 +98,7 @@ describe('UsersController', () => {
     it('should pass undefined when isActive not provided', async () => {
       mockUsersService.findAll.mockResolvedValue([mockUser]);
 
-      await controller.findAll(undefined, undefined, mockUser as any);
+      await controller.findAll(undefined, undefined, mockCurrentUser as any);
 
       expect(mockUsersService.findAll).toHaveBeenCalledWith(
         undefined,
@@ -111,14 +130,14 @@ describe('UsersController', () => {
       const result = await controller.update(
         'user-1',
         dto as any,
-        mockUser as any,
+        mockCurrentUser as any,
       );
 
       expect(result.fullName).toBe('Updated User');
       expect(mockUsersService.update).toHaveBeenCalledWith(
         'user-1',
         dto,
-        mockUser,
+        mockCurrentUserContext,
       );
     });
   });
@@ -130,10 +149,13 @@ describe('UsersController', () => {
         isActive: false,
       });
 
-      const result = await controller.remove('user-1', mockUser as any);
+      const result = await controller.remove('user-1', mockCurrentUser as any);
 
       expect(result.isActive).toBe(false);
-      expect(mockUsersService.remove).toHaveBeenCalledWith('user-1', mockUser);
+      expect(mockUsersService.remove).toHaveBeenCalledWith(
+        'user-1',
+        mockCurrentUserContext,
+      );
     });
   });
 });

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -66,7 +66,10 @@ export class UsersController {
     @Body() createUserDto: CreateUserDto,
     @CurrentUser() currentUser: User,
   ): Promise<User> {
-    return this.usersService.create(createUserDto, currentUser);
+    return this.usersService.create(createUserDto, {
+      id: currentUser.id,
+      role: currentUser.role,
+    });
   }
 
   @Get()
@@ -128,7 +131,10 @@ export class UsersController {
     @Body() updateUserDto: UpdateUserDto,
     @CurrentUser() currentUser: User,
   ): Promise<User> {
-    return this.usersService.update(id, updateUserDto, currentUser);
+    return this.usersService.update(id, updateUserDto, {
+      id: currentUser.id,
+      role: currentUser.role,
+    });
   }
 
   @Delete(':id')
@@ -145,6 +151,9 @@ export class UsersController {
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() currentUser: User,
   ): Promise<User> {
-    return this.usersService.remove(id, currentUser);
+    return this.usersService.remove(id, {
+      id: currentUser.id,
+      role: currentUser.role,
+    });
   }
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -86,9 +86,9 @@ export class UsersController {
   })
   @ApiResponse({ status: 200, description: 'List of users', type: [UserDto] })
   async findAll(
+    @Query('role') role: UserRole | undefined,
+    @Query('isActive') isActive: string | undefined,
     @CurrentUser() currentUser: User,
-    @Query('role') role?: UserRole,
-    @Query('isActive') isActive?: string,
   ): Promise<User[]> {
     let active: boolean | undefined;
     if (isActive === 'true') {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -8,6 +8,7 @@ import {
   Delete,
   Query,
   ParseUUIDPipe,
+  ParseEnumPipe,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -89,7 +90,8 @@ export class UsersController {
   })
   @ApiResponse({ status: 200, description: 'List of users', type: [UserDto] })
   async findAll(
-    @Query('role') role: UserRole | undefined,
+    @Query('role', new ParseEnumPipe(PrismaUserRole, { optional: true }))
+    role: UserRole | undefined,
     @Query('isActive') isActive: string | undefined,
     @CurrentUser() currentUser: User,
   ): Promise<User[]> {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -63,7 +63,7 @@ export class UsersController {
     @Body() createUserDto: CreateUserDto,
     @CurrentUser() currentUser: User,
   ): Promise<User> {
-    return this.usersService.create(createUserDto, currentUser.id);
+    return this.usersService.create(createUserDto, currentUser);
   }
 
   @Get()
@@ -85,6 +85,7 @@ export class UsersController {
   async findAll(
     @Query('role') role?: UserRole,
     @Query('isActive') isActive?: string,
+    @CurrentUser() currentUser?: User,
   ): Promise<User[]> {
     let active: boolean | undefined;
     if (isActive === 'true') {
@@ -92,7 +93,7 @@ export class UsersController {
     } else if (isActive === 'false') {
       active = false;
     }
-    return this.usersService.findAll(role, active);
+    return this.usersService.findAll(role, active, currentUser?.role);
   }
 
   @Get(':id')
@@ -124,7 +125,7 @@ export class UsersController {
     @Body() updateUserDto: UpdateUserDto,
     @CurrentUser() currentUser: User,
   ): Promise<User> {
-    return this.usersService.update(id, updateUserDto, currentUser.id);
+    return this.usersService.update(id, updateUserDto, currentUser);
   }
 
   @Delete(':id')

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -20,9 +20,12 @@ import {
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { UserDto, UserRole } from './dto/user.dto';
-import { UserRole as PrismaUserRole } from '../generated/prisma/client';
-import type { User } from '../generated/prisma/client';
+import { UserDto } from './dto/user.dto';
+import {
+  UserRole as PrismaUserRole,
+  type User,
+  type UserRole,
+} from '../generated/prisma/client';
 import { AdminAuthGuard, RolesGuard } from '../auth/guards';
 import { Roles, CurrentUser } from '../auth/decorators';
 
@@ -72,7 +75,7 @@ export class UsersController {
   @ApiQuery({
     name: 'role',
     required: false,
-    enum: UserRole,
+    enum: PrismaUserRole,
     description: 'Filter by role',
   })
   @ApiQuery({
@@ -83,9 +86,9 @@ export class UsersController {
   })
   @ApiResponse({ status: 200, description: 'List of users', type: [UserDto] })
   async findAll(
+    @CurrentUser() currentUser: User,
     @Query('role') role?: UserRole,
     @Query('isActive') isActive?: string,
-    @CurrentUser() currentUser?: User,
   ): Promise<User[]> {
     let active: boolean | undefined;
     if (isActive === 'true') {
@@ -93,7 +96,7 @@ export class UsersController {
     } else if (isActive === 'false') {
       active = false;
     }
-    return this.usersService.findAll(role, active, currentUser?.role);
+    return this.usersService.findAll(role, active, currentUser.role);
   }
 
   @Get(':id')
@@ -142,6 +145,6 @@ export class UsersController {
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() currentUser: User,
   ): Promise<User> {
-    return this.usersService.remove(id, currentUser.id);
+    return this.usersService.remove(id, currentUser);
   }
 }

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -179,14 +179,6 @@ describe('UsersService', () => {
   });
 
   describe('findAll', () => {
-    it('should throw BadRequestException when current user role is missing', async () => {
-      await expect(
-        service.findAll(undefined, undefined, undefined as any),
-      ).rejects.toThrow(BadRequestException);
-
-      expect(mockPrismaService.user.findMany).not.toHaveBeenCalled();
-    });
-
     it('should return all active users ordered by name', async () => {
       mockPrismaService.user.findMany.mockResolvedValue([mockUser]);
 

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -414,7 +414,7 @@ describe('UsersService', () => {
       expect(mockPrismaService.user.update).toHaveBeenCalled();
     });
 
-    it('should throw ForbiddenException when user changes their own role', async () => {
+    it('should throw ForbiddenException when changing own role', async () => {
       mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
 
       await expect(

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -49,7 +49,7 @@ describe('UsersService', () => {
   });
 
   describe('create', () => {
-    it('should create a user with correct data', async () => {
+    it('should allow admin to create admin users', async () => {
       const dto = {
         fullName: 'Test User',
         email: 'test@test.com',
@@ -87,6 +87,43 @@ describe('UsersService', () => {
       });
     });
 
+    it.each([UserRole.USER, UserRole.ADMIN, UserRole.SYSTEM_ADMINISTRATOR])(
+      'should allow system admin to create %s users',
+      async (targetRole) => {
+        const dto = {
+          fullName: 'Created User',
+          email: 'created@test.com',
+          role: targetRole,
+        };
+        const createdUser = {
+          ...mockUser,
+          id: `user-${targetRole}`,
+          fullName: 'Created User',
+          email: 'created@test.com',
+          role: targetRole,
+        };
+        mockPrismaService.user.create.mockResolvedValue(createdUser);
+
+        const result = await service.create(
+          dto as any,
+          {
+            id: 'sysadmin-1',
+            role: UserRole.SYSTEM_ADMINISTRATOR,
+          } as any,
+        );
+
+        expect(result).toEqual(createdUser);
+        expect(mockPrismaService.user.create).toHaveBeenCalledWith({
+          data: {
+            fullName: 'Created User',
+            email: 'created@test.com',
+            role: targetRole,
+            isActive: true,
+          },
+        });
+      },
+    );
+
     it('should throw BadRequestException when email is missing', async () => {
       const dto = { fullName: 'Test User' };
 
@@ -116,61 +153,40 @@ describe('UsersService', () => {
       expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
     });
 
-    it('should allow system admin to create system administrator', async () => {
-      const dto = {
-        fullName: 'System Admin User',
-        email: 'sysadmin@test.com',
-        role: UserRole.SYSTEM_ADMINISTRATOR,
-      };
-      const createdUser = {
-        ...mockUser,
-        id: 'user-2',
-        fullName: 'System Admin User',
-        email: 'sysadmin@test.com',
-        role: UserRole.SYSTEM_ADMINISTRATOR,
-      };
-      mockPrismaService.user.create.mockResolvedValue(createdUser);
+    it.each([UserRole.USER, UserRole.ADMIN, UserRole.SYSTEM_ADMINISTRATOR])(
+      'should throw ForbiddenException when user creates %s users',
+      async (targetRole) => {
+        const dto = {
+          fullName: 'Regular User Create Attempt',
+          email: 'user-attempt@test.com',
+          role: targetRole,
+        };
 
-      const result = await service.create(
-        dto as any,
-        {
-          id: 'sysadmin-1',
-          role: UserRole.SYSTEM_ADMINISTRATOR,
-        } as any,
-      );
+        await expect(
+          service.create(
+            dto as any,
+            {
+              id: 'user-actor-1',
+              role: UserRole.USER,
+            } as any,
+          ),
+        ).rejects.toThrow(ForbiddenException);
 
-      expect(result).toEqual(createdUser);
-      expect(mockPrismaService.user.create).toHaveBeenCalledWith({
-        data: {
-          fullName: 'System Admin User',
-          email: 'sysadmin@test.com',
-          role: UserRole.SYSTEM_ADMINISTRATOR,
-          isActive: true,
-        },
-      });
-      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
-        tableName: 'user',
-        recordId: 'user-2',
-        action: 'CREATE',
-        changes: [
-          {
-            field: 'fullName',
-            oldValue: null,
-            newValue: 'System Admin User',
-          },
-          { field: 'email', oldValue: null, newValue: 'sysadmin@test.com' },
-          {
-            field: 'role',
-            oldValue: null,
-            newValue: UserRole.SYSTEM_ADMINISTRATOR,
-          },
-        ],
-        userId: 'sysadmin-1',
-      });
-    });
+        expect(mockPrismaService.user.create).not.toHaveBeenCalled();
+        expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe('findAll', () => {
+    it('should throw BadRequestException when current user role is missing', async () => {
+      await expect(
+        service.findAll(undefined, undefined, undefined as any),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockPrismaService.user.findMany).not.toHaveBeenCalled();
+    });
+
     it('should return all active users ordered by name', async () => {
       mockPrismaService.user.findMany.mockResolvedValue([mockUser]);
 
@@ -419,6 +435,26 @@ describe('UsersService', () => {
 
       expect(mockPrismaService.user.update).not.toHaveBeenCalled();
     });
+
+    it('should throw ForbiddenException when non-admin updates another user', async () => {
+      const targetUser = {
+        ...mockUser,
+        id: 'user-2',
+        role: UserRole.USER,
+      };
+      mockPrismaService.user.findFirst.mockResolvedValue(targetUser);
+
+      await expect(
+        service.update(
+          'user-2',
+          { fullName: 'Updated User' } as any,
+          { id: 'user-1', role: UserRole.USER } as any,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(mockPrismaService.user.update).not.toHaveBeenCalled();
+      expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
+    });
   });
 
   describe('remove', () => {
@@ -514,6 +550,25 @@ describe('UsersService', () => {
           role: UserRole.ADMIN,
         } as any),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when non-admin deletes another user', async () => {
+      const targetUser = {
+        ...mockUser,
+        id: 'user-2',
+        role: UserRole.USER,
+      };
+      mockPrismaService.user.findFirst.mockResolvedValue(targetUser);
+
+      await expect(
+        service.remove('user-2', {
+          id: 'user-1',
+          role: UserRole.USER,
+        } as any),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(mockPrismaService.user.update).not.toHaveBeenCalled();
+      expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -7,6 +7,7 @@ import {
 import { UsersService } from './users.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
+import { UserRole } from '../generated/prisma/client';
 
 const mockPrismaService = {
   user: {
@@ -25,7 +26,7 @@ const mockUser = {
   id: 'user-1',
   fullName: 'Test User',
   email: 'test@test.com',
-  role: 'ADMIN',
+  role: UserRole.ADMIN,
   isActive: true,
   deletedAt: null,
   createdAt: new Date(),
@@ -52,7 +53,7 @@ describe('UsersService', () => {
       const dto = {
         fullName: 'Test User',
         email: 'test@test.com',
-        role: 'ADMIN',
+        role: UserRole.ADMIN,
       };
       mockPrismaService.user.create.mockResolvedValue(mockUser);
 
@@ -60,7 +61,7 @@ describe('UsersService', () => {
         dto as any,
         {
           id: 'admin-1',
-          role: 'ADMIN',
+          role: UserRole.ADMIN,
         } as any,
       );
 
@@ -69,7 +70,7 @@ describe('UsersService', () => {
         data: {
           fullName: 'Test User',
           email: 'test@test.com',
-          role: 'ADMIN',
+          role: UserRole.ADMIN,
           isActive: true,
         },
       });
@@ -80,7 +81,7 @@ describe('UsersService', () => {
         changes: [
           { field: 'fullName', oldValue: null, newValue: 'Test User' },
           { field: 'email', oldValue: null, newValue: 'test@test.com' },
-          { field: 'role', oldValue: null, newValue: 'ADMIN' },
+          { field: 'role', oldValue: null, newValue: UserRole.ADMIN },
         ],
         userId: 'admin-1',
       });
@@ -90,7 +91,10 @@ describe('UsersService', () => {
       const dto = { fullName: 'Test User' };
 
       await expect(
-        service.create(dto as any, { id: 'admin-1', role: 'ADMIN' } as any),
+        service.create(
+          dto as any,
+          { id: 'admin-1', role: UserRole.ADMIN } as any,
+        ),
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -98,11 +102,14 @@ describe('UsersService', () => {
       const dto = {
         fullName: 'System Admin User',
         email: 'sysadmin@test.com',
-        role: 'SYSTEM_ADMINISTRATOR',
+        role: UserRole.SYSTEM_ADMINISTRATOR,
       };
 
       await expect(
-        service.create(dto as any, { id: 'admin-1', role: 'ADMIN' } as any),
+        service.create(
+          dto as any,
+          { id: 'admin-1', role: UserRole.ADMIN } as any,
+        ),
       ).rejects.toThrow(ForbiddenException);
 
       expect(mockPrismaService.user.create).not.toHaveBeenCalled();
@@ -113,14 +120,14 @@ describe('UsersService', () => {
       const dto = {
         fullName: 'System Admin User',
         email: 'sysadmin@test.com',
-        role: 'SYSTEM_ADMINISTRATOR',
+        role: UserRole.SYSTEM_ADMINISTRATOR,
       };
       const createdUser = {
         ...mockUser,
         id: 'user-2',
         fullName: 'System Admin User',
         email: 'sysadmin@test.com',
-        role: 'SYSTEM_ADMINISTRATOR',
+        role: UserRole.SYSTEM_ADMINISTRATOR,
       };
       mockPrismaService.user.create.mockResolvedValue(createdUser);
 
@@ -128,7 +135,7 @@ describe('UsersService', () => {
         dto as any,
         {
           id: 'sysadmin-1',
-          role: 'SYSTEM_ADMINISTRATOR',
+          role: UserRole.SYSTEM_ADMINISTRATOR,
         } as any,
       );
 
@@ -137,7 +144,7 @@ describe('UsersService', () => {
         data: {
           fullName: 'System Admin User',
           email: 'sysadmin@test.com',
-          role: 'SYSTEM_ADMINISTRATOR',
+          role: UserRole.SYSTEM_ADMINISTRATOR,
           isActive: true,
         },
       });
@@ -155,7 +162,7 @@ describe('UsersService', () => {
           {
             field: 'role',
             oldValue: null,
-            newValue: 'SYSTEM_ADMINISTRATOR',
+            newValue: UserRole.SYSTEM_ADMINISTRATOR,
           },
         ],
         userId: 'sysadmin-1',
@@ -170,7 +177,7 @@ describe('UsersService', () => {
       const result = await service.findAll(
         undefined,
         undefined,
-        'SYSTEM_ADMINISTRATOR',
+        UserRole.SYSTEM_ADMINISTRATOR,
       );
 
       expect(result).toEqual([mockUser]);
@@ -187,11 +194,15 @@ describe('UsersService', () => {
     it('should filter by role', async () => {
       mockPrismaService.user.findMany.mockResolvedValue([mockUser]);
 
-      await service.findAll('ADMIN' as any, undefined, 'SYSTEM_ADMINISTRATOR');
+      await service.findAll(
+        UserRole.ADMIN,
+        undefined,
+        UserRole.SYSTEM_ADMINISTRATOR,
+      );
 
       expect(mockPrismaService.user.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: expect.objectContaining({ role: 'ADMIN' }),
+          where: expect.objectContaining({ role: UserRole.ADMIN }),
         }),
       );
     });
@@ -199,7 +210,7 @@ describe('UsersService', () => {
     it('should filter by isActive', async () => {
       mockPrismaService.user.findMany.mockResolvedValue([mockUser]);
 
-      await service.findAll(undefined, true, 'SYSTEM_ADMINISTRATOR');
+      await service.findAll(undefined, true, UserRole.SYSTEM_ADMINISTRATOR);
 
       expect(mockPrismaService.user.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -211,11 +222,26 @@ describe('UsersService', () => {
     it('should exclude system administrators for admin callers', async () => {
       mockPrismaService.user.findMany.mockResolvedValue([mockUser]);
 
-      await service.findAll(undefined, undefined, 'ADMIN');
+      await service.findAll(undefined, undefined, UserRole.ADMIN);
 
       expect(mockPrismaService.user.findMany).toHaveBeenCalledWith({
         where: {
-          role: { in: ['USER', 'ADMIN'] },
+          role: { in: [UserRole.USER, UserRole.ADMIN] },
+          isActive: undefined,
+          deletedAt: null,
+        },
+        orderBy: { fullName: 'asc' },
+      });
+    });
+
+    it('should exclude system administrators for non-system-admin callers', async () => {
+      mockPrismaService.user.findMany.mockResolvedValue([mockUser]);
+
+      await service.findAll(undefined, undefined, UserRole.USER);
+
+      expect(mockPrismaService.user.findMany).toHaveBeenCalledWith({
+        where: {
+          role: { in: [UserRole.USER, UserRole.ADMIN] },
           isActive: undefined,
           deletedAt: null,
         },
@@ -225,9 +251,9 @@ describe('UsersService', () => {
 
     it('should return empty result when admin requests system administrators', async () => {
       const result = await service.findAll(
-        'SYSTEM_ADMINISTRATOR' as any,
+        UserRole.SYSTEM_ADMINISTRATOR,
         undefined,
-        'ADMIN',
+        UserRole.ADMIN,
       );
 
       expect(result).toEqual([]);
@@ -267,7 +293,7 @@ describe('UsersService', () => {
         {
           fullName: 'Updated User',
         } as any,
-        { id: 'admin-1', role: 'ADMIN' } as any,
+        { id: 'admin-1', role: UserRole.ADMIN } as any,
       );
 
       expect(result.fullName).toBe('Updated User');
@@ -301,7 +327,7 @@ describe('UsersService', () => {
         } as any,
         {
           id: 'admin-1',
-          role: 'ADMIN',
+          role: UserRole.ADMIN,
         } as any,
       );
 
@@ -317,7 +343,7 @@ describe('UsersService', () => {
           {} as any,
           {
             id: 'admin-1',
-            role: 'ADMIN',
+            role: UserRole.ADMIN,
           } as any,
         ),
       ).rejects.toThrow(NotFoundException);
@@ -329,8 +355,27 @@ describe('UsersService', () => {
       await expect(
         service.update(
           'user-1',
-          { role: 'SYSTEM_ADMINISTRATOR' } as any,
-          { id: 'admin-1', role: 'ADMIN' } as any,
+          { role: UserRole.SYSTEM_ADMINISTRATOR } as any,
+          { id: 'admin-1', role: UserRole.ADMIN } as any,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(mockPrismaService.user.update).not.toHaveBeenCalled();
+      expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException when admin updates a system administrator without role change', async () => {
+      const systemAdmin = {
+        ...mockUser,
+        role: UserRole.SYSTEM_ADMINISTRATOR,
+      };
+      mockPrismaService.user.findFirst.mockResolvedValue(systemAdmin);
+
+      await expect(
+        service.update(
+          'user-1',
+          { fullName: 'Updated User' } as any,
+          { id: 'admin-1', role: UserRole.ADMIN } as any,
         ),
       ).rejects.toThrow(ForbiddenException);
 
@@ -345,7 +390,10 @@ describe('UsersService', () => {
       mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
       mockPrismaService.user.update.mockResolvedValue(deleted);
 
-      const result = await service.remove('user-1', 'admin-1');
+      const result = await service.remove('user-1', {
+        id: 'admin-1',
+        role: UserRole.ADMIN,
+      } as any);
 
       expect(result.isActive).toBe(false);
       expect(result.deletedAt).toBeDefined();
@@ -365,12 +413,33 @@ describe('UsersService', () => {
       });
     });
 
+    it('should throw ForbiddenException when admin deletes a system administrator', async () => {
+      const systemAdmin = {
+        ...mockUser,
+        role: UserRole.SYSTEM_ADMINISTRATOR,
+      };
+      mockPrismaService.user.findFirst.mockResolvedValue(systemAdmin);
+
+      await expect(
+        service.remove('user-1', {
+          id: 'admin-1',
+          role: UserRole.ADMIN,
+        } as any),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(mockPrismaService.user.update).not.toHaveBeenCalled();
+      expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
+    });
+
     it('should throw NotFoundException for nonexistent user', async () => {
       mockPrismaService.user.findFirst.mockResolvedValue(null);
 
-      await expect(service.remove('nonexistent')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.remove('nonexistent', {
+          id: 'admin-1',
+          role: UserRole.ADMIN,
+        } as any),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -382,6 +382,43 @@ describe('UsersService', () => {
       expect(mockPrismaService.user.update).not.toHaveBeenCalled();
       expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
     });
+
+    it('should allow system admin to update another system administrator', async () => {
+      const systemAdmin = {
+        ...mockUser,
+        id: 'sysadmin-2',
+        role: UserRole.SYSTEM_ADMINISTRATOR,
+      };
+      const updated = { ...systemAdmin, fullName: 'Updated SysAdmin' };
+      mockPrismaService.user.findFirst.mockResolvedValue(systemAdmin);
+      mockPrismaService.user.update.mockResolvedValue(updated);
+
+      const result = await service.update(
+        'sysadmin-2',
+        { fullName: 'Updated SysAdmin' } as any,
+        {
+          id: 'sysadmin-1',
+          role: UserRole.SYSTEM_ADMINISTRATOR,
+        } as any,
+      );
+
+      expect(result.fullName).toBe('Updated SysAdmin');
+      expect(mockPrismaService.user.update).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException when user changes their own role', async () => {
+      mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
+
+      await expect(
+        service.update(
+          'user-1',
+          { role: UserRole.USER } as any,
+          { id: 'user-1', role: UserRole.ADMIN } as any,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(mockPrismaService.user.update).not.toHaveBeenCalled();
+    });
   });
 
   describe('remove', () => {
@@ -429,6 +466,43 @@ describe('UsersService', () => {
 
       expect(mockPrismaService.user.update).not.toHaveBeenCalled();
       expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
+    });
+
+    it('should allow system admin to delete another system administrator', async () => {
+      const systemAdmin = {
+        ...mockUser,
+        id: 'sysadmin-2',
+        role: UserRole.SYSTEM_ADMINISTRATOR,
+      };
+      const deleted = {
+        ...systemAdmin,
+        isActive: false,
+        deletedAt: new Date(),
+      };
+      mockPrismaService.user.findFirst.mockResolvedValue(systemAdmin);
+      mockPrismaService.user.update.mockResolvedValue(deleted);
+
+      const result = await service.remove('sysadmin-2', {
+        id: 'sysadmin-1',
+        role: UserRole.SYSTEM_ADMINISTRATOR,
+      } as any);
+
+      expect(result.isActive).toBe(false);
+      expect(result.deletedAt).toBeDefined();
+      expect(mockPrismaService.user.update).toHaveBeenCalled();
+      expect(mockAuditService.logGlobal).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException when user deletes themselves', async () => {
+      await expect(
+        service.remove('user-1', {
+          id: 'user-1',
+          role: UserRole.ADMIN,
+        } as any),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(mockPrismaService.user.findFirst).not.toHaveBeenCalled();
+      expect(mockPrismaService.user.update).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException for nonexistent user', async () => {

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,5 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { UsersService } from './users.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
@@ -52,7 +56,13 @@ describe('UsersService', () => {
       };
       mockPrismaService.user.create.mockResolvedValue(mockUser);
 
-      const result = await service.create(dto as any, 'admin-1');
+      const result = await service.create(
+        dto as any,
+        {
+          id: 'admin-1',
+          role: 'ADMIN',
+        } as any,
+      );
 
       expect(result).toEqual(mockUser);
       expect(mockPrismaService.user.create).toHaveBeenCalledWith({
@@ -79,9 +89,77 @@ describe('UsersService', () => {
     it('should throw BadRequestException when email is missing', async () => {
       const dto = { fullName: 'Test User' };
 
-      await expect(service.create(dto as any)).rejects.toThrow(
-        BadRequestException,
+      await expect(
+        service.create(dto as any, { id: 'admin-1', role: 'ADMIN' } as any),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw ForbiddenException when admin creates system administrator', async () => {
+      const dto = {
+        fullName: 'System Admin User',
+        email: 'sysadmin@test.com',
+        role: 'SYSTEM_ADMINISTRATOR',
+      };
+
+      await expect(
+        service.create(dto as any, { id: 'admin-1', role: 'ADMIN' } as any),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(mockPrismaService.user.create).not.toHaveBeenCalled();
+      expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
+    });
+
+    it('should allow system admin to create system administrator', async () => {
+      const dto = {
+        fullName: 'System Admin User',
+        email: 'sysadmin@test.com',
+        role: 'SYSTEM_ADMINISTRATOR',
+      };
+      const createdUser = {
+        ...mockUser,
+        id: 'user-2',
+        fullName: 'System Admin User',
+        email: 'sysadmin@test.com',
+        role: 'SYSTEM_ADMINISTRATOR',
+      };
+      mockPrismaService.user.create.mockResolvedValue(createdUser);
+
+      const result = await service.create(
+        dto as any,
+        {
+          id: 'sysadmin-1',
+          role: 'SYSTEM_ADMINISTRATOR',
+        } as any,
       );
+
+      expect(result).toEqual(createdUser);
+      expect(mockPrismaService.user.create).toHaveBeenCalledWith({
+        data: {
+          fullName: 'System Admin User',
+          email: 'sysadmin@test.com',
+          role: 'SYSTEM_ADMINISTRATOR',
+          isActive: true,
+        },
+      });
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith({
+        tableName: 'user',
+        recordId: 'user-2',
+        action: 'CREATE',
+        changes: [
+          {
+            field: 'fullName',
+            oldValue: null,
+            newValue: 'System Admin User',
+          },
+          { field: 'email', oldValue: null, newValue: 'sysadmin@test.com' },
+          {
+            field: 'role',
+            oldValue: null,
+            newValue: 'SYSTEM_ADMINISTRATOR',
+          },
+        ],
+        userId: 'sysadmin-1',
+      });
     });
   });
 
@@ -89,7 +167,11 @@ describe('UsersService', () => {
     it('should return all active users ordered by name', async () => {
       mockPrismaService.user.findMany.mockResolvedValue([mockUser]);
 
-      const result = await service.findAll();
+      const result = await service.findAll(
+        undefined,
+        undefined,
+        'SYSTEM_ADMINISTRATOR',
+      );
 
       expect(result).toEqual([mockUser]);
       expect(mockPrismaService.user.findMany).toHaveBeenCalledWith({
@@ -105,7 +187,7 @@ describe('UsersService', () => {
     it('should filter by role', async () => {
       mockPrismaService.user.findMany.mockResolvedValue([mockUser]);
 
-      await service.findAll('ADMIN' as any);
+      await service.findAll('ADMIN' as any, undefined, 'SYSTEM_ADMINISTRATOR');
 
       expect(mockPrismaService.user.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -117,13 +199,39 @@ describe('UsersService', () => {
     it('should filter by isActive', async () => {
       mockPrismaService.user.findMany.mockResolvedValue([mockUser]);
 
-      await service.findAll(undefined, true);
+      await service.findAll(undefined, true, 'SYSTEM_ADMINISTRATOR');
 
       expect(mockPrismaService.user.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({ isActive: true }),
         }),
       );
+    });
+
+    it('should exclude system administrators for admin callers', async () => {
+      mockPrismaService.user.findMany.mockResolvedValue([mockUser]);
+
+      await service.findAll(undefined, undefined, 'ADMIN');
+
+      expect(mockPrismaService.user.findMany).toHaveBeenCalledWith({
+        where: {
+          role: { in: ['USER', 'ADMIN'] },
+          isActive: undefined,
+          deletedAt: null,
+        },
+        orderBy: { fullName: 'asc' },
+      });
+    });
+
+    it('should return empty result when admin requests system administrators', async () => {
+      const result = await service.findAll(
+        'SYSTEM_ADMINISTRATOR' as any,
+        undefined,
+        'ADMIN',
+      );
+
+      expect(result).toEqual([]);
+      expect(mockPrismaService.user.findMany).not.toHaveBeenCalled();
     });
   });
 
@@ -159,7 +267,7 @@ describe('UsersService', () => {
         {
           fullName: 'Updated User',
         } as any,
-        'admin-1',
+        { id: 'admin-1', role: 'ADMIN' } as any,
       );
 
       expect(result.fullName).toBe('Updated User');
@@ -186,9 +294,16 @@ describe('UsersService', () => {
       mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
       mockPrismaService.user.update.mockResolvedValue(mockUser);
 
-      await service.update('user-1', {
-        fullName: 'Test User',
-      } as any);
+      await service.update(
+        'user-1',
+        {
+          fullName: 'Test User',
+        } as any,
+        {
+          id: 'admin-1',
+          role: 'ADMIN',
+        } as any,
+      );
 
       expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
     });
@@ -196,9 +311,31 @@ describe('UsersService', () => {
     it('should throw NotFoundException for nonexistent user', async () => {
       mockPrismaService.user.findFirst.mockResolvedValue(null);
 
-      await expect(service.update('nonexistent', {} as any)).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.update(
+          'nonexistent',
+          {} as any,
+          {
+            id: 'admin-1',
+            role: 'ADMIN',
+          } as any,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when admin updates role to system administrator', async () => {
+      mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
+
+      await expect(
+        service.update(
+          'user-1',
+          { role: 'SYSTEM_ADMINISTRATOR' } as any,
+          { id: 'admin-1', role: 'ADMIN' } as any,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(mockPrismaService.user.update).not.toHaveBeenCalled();
+      expect(mockAuditService.logGlobal).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -59,10 +59,6 @@ export class UsersService {
     isActive: boolean | undefined,
     currentUserRole: UserRole,
   ): Promise<User[]> {
-    if (!currentUserRole) {
-      throw new BadRequestException('Current user role is required');
-    }
-
     const isRestrictedCaller =
       currentUserRole !== UserRole.SYSTEM_ADMINISTRATOR;
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -9,8 +9,7 @@ import { AuditService } from '../audit/audit.service';
 import { diffObjects } from '../audit/audit.utils';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { UserRole } from './dto/user.dto';
-import { User } from '../generated/prisma/client';
+import { User, UserRole } from '../generated/prisma/client';
 
 const TRACKED_FIELDS = ['fullName', 'email', 'role', 'isActive'];
 
@@ -58,18 +57,18 @@ export class UsersService {
   async findAll(
     role?: UserRole,
     isActive?: boolean,
-    currentUserRole?: string,
+    currentUserRole?: UserRole,
   ): Promise<User[]> {
-    if (
-      currentUserRole === UserRole.ADMIN &&
-      role === UserRole.SYSTEM_ADMINISTRATOR
-    ) {
+    const isRestrictedCaller =
+      currentUserRole !== UserRole.SYSTEM_ADMINISTRATOR;
+
+    if (isRestrictedCaller && role === UserRole.SYSTEM_ADMINISTRATOR) {
       return [];
     }
 
     const roleFilter =
       role ??
-      (currentUserRole === UserRole.ADMIN
+      (isRestrictedCaller
         ? {
             in: [UserRole.USER, UserRole.ADMIN],
           }
@@ -109,6 +108,8 @@ export class UsersService {
   ): Promise<User> {
     const existing = await this.findOne(id);
 
+    this.assertCanManageUser(currentUser.role, existing.role);
+
     if (updateUserDto.role) {
       this.assertCanAssignRole(currentUser.role, updateUserDto.role);
     }
@@ -138,8 +139,13 @@ export class UsersService {
     return updated;
   }
 
-  async remove(id: string, userId?: string): Promise<User> {
-    await this.findOne(id);
+  async remove(
+    id: string,
+    currentUser: Pick<User, 'id' | 'role'>,
+  ): Promise<User> {
+    const existing = await this.findOne(id);
+
+    this.assertCanManageUser(currentUser.role, existing.role);
 
     const removed = await this.prisma.user.update({
       where: { id },
@@ -154,26 +160,46 @@ export class UsersService {
       recordId: id,
       action: 'DELETE',
       changes: [],
-      userId,
+      userId: currentUser.id,
     });
 
     return removed;
   }
 
-  private assertCanAssignRole(actingRole: string, targetRole: UserRole): void {
+  private assertCanAssignRole(
+    actingRole: UserRole,
+    targetRole: UserRole,
+  ): void {
     if (actingRole === UserRole.SYSTEM_ADMINISTRATOR) {
       return;
     }
 
     if (
       actingRole === UserRole.ADMIN &&
-      [UserRole.ADMIN, UserRole.USER].includes(targetRole)
+      (targetRole === UserRole.ADMIN || targetRole === UserRole.USER)
     ) {
       return;
     }
 
     throw new ForbiddenException(
       'Insufficient permissions to assign the requested role',
+    );
+  }
+
+  private assertCanManageUser(
+    actingRole: UserRole,
+    targetRole: UserRole,
+  ): void {
+    if (targetRole !== UserRole.SYSTEM_ADMINISTRATOR) {
+      return;
+    }
+
+    if (actingRole === UserRole.SYSTEM_ADMINISTRATOR) {
+      return;
+    }
+
+    throw new ForbiddenException(
+      'Insufficient permissions to manage the target user',
     );
   }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -55,10 +55,14 @@ export class UsersService {
   }
 
   async findAll(
-    role?: UserRole,
-    isActive?: boolean,
-    currentUserRole: UserRole = UserRole.USER,
+    role: UserRole | undefined,
+    isActive: boolean | undefined,
+    currentUserRole: UserRole,
   ): Promise<User[]> {
+    if (!currentUserRole) {
+      throw new BadRequestException('Current user role is required');
+    }
+
     const isRestrictedCaller =
       currentUserRole !== UserRole.SYSTEM_ADMINISTRATOR;
 
@@ -202,11 +206,15 @@ export class UsersService {
     actingRole: UserRole,
     targetRole: UserRole,
   ): void {
-    if (targetRole !== UserRole.SYSTEM_ADMINISTRATOR) {
+    if (actingRole === UserRole.SYSTEM_ADMINISTRATOR) {
       return;
     }
 
-    if (actingRole === UserRole.SYSTEM_ADMINISTRATOR) {
+    if (actingRole !== UserRole.ADMIN) {
+      throw new ForbiddenException('Insufficient permissions to manage users');
+    }
+
+    if (targetRole !== UserRole.SYSTEM_ADMINISTRATOR) {
       return;
     }
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -57,7 +57,7 @@ export class UsersService {
   async findAll(
     role?: UserRole,
     isActive?: boolean,
-    currentUserRole?: UserRole,
+    currentUserRole: UserRole = UserRole.USER,
   ): Promise<User[]> {
     const isRestrictedCaller =
       currentUserRole !== UserRole.SYSTEM_ADMINISTRATOR;
@@ -108,6 +108,14 @@ export class UsersService {
   ): Promise<User> {
     const existing = await this.findOne(id);
 
+    if (
+      currentUser.id === id &&
+      updateUserDto.role &&
+      updateUserDto.role !== existing.role
+    ) {
+      throw new ForbiddenException('Cannot change your own role');
+    }
+
     this.assertCanManageUser(currentUser.role, existing.role);
 
     if (updateUserDto.role) {
@@ -143,6 +151,10 @@ export class UsersService {
     id: string,
     currentUser: Pick<User, 'id' | 'role'>,
   ): Promise<User> {
+    if (currentUser.id === id) {
+      throw new ForbiddenException('Cannot delete your own account');
+    }
+
     const existing = await this.findOne(id);
 
     this.assertCanManageUser(currentUser.role, existing.role);

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
@@ -20,10 +21,15 @@ export class UsersService {
     private readonly auditService: AuditService,
   ) {}
 
-  async create(createUserDto: CreateUserDto, userId?: string): Promise<User> {
+  async create(
+    createUserDto: CreateUserDto,
+    currentUser: Pick<User, 'id' | 'role'>,
+  ): Promise<User> {
     if (!createUserDto.email) {
       throw new BadRequestException('Email is required');
     }
+
+    this.assertCanAssignRole(currentUser.role, createUserDto.role);
 
     const user = await this.prisma.user.create({
       data: {
@@ -43,16 +49,35 @@ export class UsersService {
         { field: 'email', oldValue: null, newValue: user.email },
         { field: 'role', oldValue: null, newValue: user.role },
       ],
-      userId,
+      userId: currentUser.id,
     });
 
     return user;
   }
 
-  async findAll(role?: UserRole, isActive?: boolean): Promise<User[]> {
+  async findAll(
+    role?: UserRole,
+    isActive?: boolean,
+    currentUserRole?: string,
+  ): Promise<User[]> {
+    if (
+      currentUserRole === UserRole.ADMIN &&
+      role === UserRole.SYSTEM_ADMINISTRATOR
+    ) {
+      return [];
+    }
+
+    const roleFilter =
+      role ??
+      (currentUserRole === UserRole.ADMIN
+        ? {
+            in: [UserRole.USER, UserRole.ADMIN],
+          }
+        : undefined);
+
     return this.prisma.user.findMany({
       where: {
-        role,
+        role: roleFilter,
         isActive,
         deletedAt: null,
       },
@@ -80,20 +105,20 @@ export class UsersService {
   async update(
     id: string,
     updateUserDto: UpdateUserDto,
-    userId?: string,
+    currentUser: Pick<User, 'id' | 'role'>,
   ): Promise<User> {
     const existing = await this.findOne(id);
+
+    if (updateUserDto.role) {
+      this.assertCanAssignRole(currentUser.role, updateUserDto.role);
+    }
 
     const data = { ...updateUserDto };
     if (data.email) {
       data.email = data.email.toLowerCase();
     }
 
-    const changes = diffObjects(
-      existing as unknown as Record<string, unknown>,
-      data as unknown as Record<string, unknown>,
-      TRACKED_FIELDS,
-    );
+    const changes = diffObjects(existing, data, TRACKED_FIELDS);
 
     const updated = await this.prisma.user.update({
       where: { id },
@@ -106,7 +131,7 @@ export class UsersService {
         recordId: id,
         action: 'UPDATE',
         changes,
-        userId,
+        userId: currentUser.id,
       });
     }
 
@@ -133,5 +158,22 @@ export class UsersService {
     });
 
     return removed;
+  }
+
+  private assertCanAssignRole(actingRole: string, targetRole: UserRole): void {
+    if (actingRole === UserRole.SYSTEM_ADMINISTRATOR) {
+      return;
+    }
+
+    if (
+      actingRole === UserRole.ADMIN &&
+      [UserRole.ADMIN, UserRole.USER].includes(targetRole)
+    ) {
+      return;
+    }
+
+    throw new ForbiddenException(
+      'Insufficient permissions to assign the requested role',
+    );
   }
 }


### PR DESCRIPTION
Backend: Enforce RBAC in users service and controller by passing the currentUser object (id and role) into service methods instead of raw ids, adding ForbiddenException checks, and introducing assertCanAssignRole to prevent non-system-admins from assigning SYSTEM_ADMINISTRATOR role. findAll now accepts caller role to filter/hide system administrators for ADMIN callers and returns empty when an admin queries system admins. Audit logging and updates use currentUser.id. Updated service logic (diffObjects usage) and added comprehensive tests for create/findAll/update scenarios.

Frontend: Restrict access to the Users page and navigation based on currentUser.role. Layout now conditionally includes the Users nav item; Users redirected to referrals for regular users, limits assignable roles based on caller role, and uses useCurrentUser to determine behaviour. Updated UI defaults and form role options to reflect assignable roles.