### PR TITLE
Relax status transition checks and update tests

### DIFF
--- a/backend/src/referrals/referrals.service.spec.ts
+++ b/backend/src/referrals/referrals.service.spec.ts
@@ -708,7 +708,26 @@ describe('ReferralsService', () => {
     });
 
     describe('status transition validation', () => {
-      it('should reject invalid transition from OPEN to CLOSED', async () => {
+      it('should allow transition from OPEN to CLOSED with referralOutcome', async () => {
+        const existing = createMockReferral({
+          referralStatus: ReferralStatus.OPEN,
+        });
+        const updated = createMockReferral({
+          referralStatus: ReferralStatus.CLOSED,
+          referralOutcome: ReferralOutcome.SERVICES_PROVIDED,
+        });
+        mockPrismaService.referral.findUnique.mockResolvedValue(existing);
+        mockPrismaService.referral.update.mockResolvedValue(updated);
+
+        const result = await service.update('referral-uuid-1', {
+          referralStatus: ReferralStatus.CLOSED,
+          referralOutcome: ReferralOutcome.SERVICES_PROVIDED,
+        });
+
+        expect(result.referralStatus).toBe(ReferralStatus.CLOSED);
+      });
+
+      it('should require referralOutcome when transitioning from OPEN to CLOSED', async () => {
         const existing = createMockReferral({
           referralStatus: ReferralStatus.OPEN,
         });
@@ -717,48 +736,42 @@ describe('ReferralsService', () => {
         await expect(
           service.update('referral-uuid-1', {
             referralStatus: ReferralStatus.CLOSED,
-            referralOutcome: ReferralOutcome.SERVICES_PROVIDED,
           }),
-        ).rejects.toThrow(BadRequestException);
+        ).rejects.toThrow('A referral outcome must be selected');
       });
 
-      it('should reject invalid transition from OPEN to CONTACT_MADE', async () => {
+      it('should allow transition from OPEN to CONTACT_MADE', async () => {
         const existing = createMockReferral({
           referralStatus: ReferralStatus.OPEN,
         });
+        const updated = createMockReferral({
+          referralStatus: ReferralStatus.CONTACT_MADE,
+        });
         mockPrismaService.referral.findUnique.mockResolvedValue(existing);
+        mockPrismaService.referral.update.mockResolvedValue(updated);
 
-        await expect(
-          service.update('referral-uuid-1', {
-            referralStatus: ReferralStatus.CONTACT_MADE,
-          }),
-        ).rejects.toThrow(BadRequestException);
+        const result = await service.update('referral-uuid-1', {
+          referralStatus: ReferralStatus.CONTACT_MADE,
+        });
+
+        expect(result.referralStatus).toBe(ReferralStatus.CONTACT_MADE);
       });
 
-      it('should reject transition from CLOSED to any status', async () => {
+      it('should allow transition from CLOSED to another status', async () => {
         const existing = createMockReferral({
           referralStatus: ReferralStatus.CLOSED,
         });
-        mockPrismaService.referral.findUnique.mockResolvedValue(existing);
-
-        await expect(
-          service.update('referral-uuid-1', {
-            referralStatus: ReferralStatus.OPEN,
-          }),
-        ).rejects.toThrow(BadRequestException);
-      });
-
-      it('should require assignedToId when transitioning to ASSIGNED', async () => {
-        const existing = createMockReferral({
+        const updated = createMockReferral({
           referralStatus: ReferralStatus.OPEN,
         });
         mockPrismaService.referral.findUnique.mockResolvedValue(existing);
+        mockPrismaService.referral.update.mockResolvedValue(updated);
 
-        await expect(
-          service.update('referral-uuid-1', {
-            referralStatus: ReferralStatus.ASSIGNED,
-          }),
-        ).rejects.toThrow('A team member must be assigned');
+        const result = await service.update('referral-uuid-1', {
+          referralStatus: ReferralStatus.OPEN,
+        });
+
+        expect(result.referralStatus).toBe(ReferralStatus.OPEN);
       });
 
       it('should require referralOutcome when transitioning to CLOSED', async () => {
@@ -962,7 +975,26 @@ describe('ReferralsService', () => {
         expect(result.referralStatus).toBe(ReferralStatus.CLOSED);
       });
 
-      it('should reject invalid transition from ASSIGNED to CLOSED', async () => {
+      it('should allow transition from ASSIGNED to CLOSED with referralOutcome', async () => {
+        const existing = createMockReferral({
+          referralStatus: ReferralStatus.ASSIGNED,
+        });
+        const updated = createMockReferral({
+          referralStatus: ReferralStatus.CLOSED,
+          referralOutcome: ReferralOutcome.SERVICES_PROVIDED,
+        });
+        mockPrismaService.referral.findUnique.mockResolvedValue(existing);
+        mockPrismaService.referral.update.mockResolvedValue(updated);
+
+        const result = await service.update('referral-uuid-1', {
+          referralStatus: ReferralStatus.CLOSED,
+          referralOutcome: ReferralOutcome.SERVICES_PROVIDED,
+        });
+
+        expect(result.referralStatus).toBe(ReferralStatus.CLOSED);
+      });
+
+      it('should require referralOutcome when transitioning from ASSIGNED to CLOSED', async () => {
         const existing = createMockReferral({
           referralStatus: ReferralStatus.ASSIGNED,
         });
@@ -971,22 +1003,25 @@ describe('ReferralsService', () => {
         await expect(
           service.update('referral-uuid-1', {
             referralStatus: ReferralStatus.CLOSED,
-            referralOutcome: ReferralOutcome.SERVICES_PROVIDED,
           }),
-        ).rejects.toThrow(BadRequestException);
+        ).rejects.toThrow('A referral outcome must be selected');
       });
 
-      it('should reject invalid transition from CONTACT_MADE to OPEN', async () => {
+      it('should allow transition from CONTACT_MADE to OPEN', async () => {
         const existing = createMockReferral({
           referralStatus: ReferralStatus.CONTACT_MADE,
         });
+        const updated = createMockReferral({
+          referralStatus: ReferralStatus.OPEN,
+        });
         mockPrismaService.referral.findUnique.mockResolvedValue(existing);
+        mockPrismaService.referral.update.mockResolvedValue(updated);
 
-        await expect(
-          service.update('referral-uuid-1', {
-            referralStatus: ReferralStatus.OPEN,
-          }),
-        ).rejects.toThrow(BadRequestException);
+        const result = await service.update('referral-uuid-1', {
+          referralStatus: ReferralStatus.OPEN,
+        });
+
+        expect(result.referralStatus).toBe(ReferralStatus.OPEN);
       });
 
       it('should auto-transition to CONTACT_MADE when firstContactMadeOn is set while ASSIGNED', async () => {

--- a/backend/src/referrals/referrals.service.ts
+++ b/backend/src/referrals/referrals.service.ts
@@ -66,22 +66,6 @@ export class ReferralsService {
   private static readonly MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
   private static readonly EXPORT_MAX_ROWS = 10000;
 
-  private static readonly VALID_STATUS_TRANSITIONS: Record<
-    ReferralStatus,
-    ReferralStatus[]
-  > = {
-    [ReferralStatus.OPEN]: [ReferralStatus.ASSIGNED],
-    [ReferralStatus.ASSIGNED]: [
-      ReferralStatus.CONTACT_MADE,
-      ReferralStatus.OPEN,
-    ],
-    [ReferralStatus.CONTACT_MADE]: [
-      ReferralStatus.CLOSED,
-      ReferralStatus.ASSIGNED,
-    ],
-    [ReferralStatus.CLOSED]: [],
-  };
-
   private readonly logger = new Logger('REFERRALS');
 
   constructor(
@@ -96,21 +80,6 @@ export class ReferralsService {
     dto: UpdateReferralDto,
     existing: Referral,
   ): void {
-    const allowed =
-      ReferralsService.VALID_STATUS_TRANSITIONS[currentStatus] ?? [];
-    if (!allowed.includes(newStatus)) {
-      throw new BadRequestException(
-        `Status cannot be changed from ${currentStatus} to ${newStatus}`,
-      );
-    }
-
-    const effectiveAssignedToId = dto.assignedToId ?? existing.assignedToId;
-    if (newStatus === ReferralStatus.ASSIGNED && !effectiveAssignedToId) {
-      throw new BadRequestException(
-        'A team member must be assigned before setting the status to Assigned',
-      );
-    }
-
     const effectiveOutcome = dto.referralOutcome ?? existing.referralOutcome;
     if (newStatus === ReferralStatus.CLOSED && !effectiveOutcome) {
       throw new BadRequestException(
@@ -566,11 +535,7 @@ export class ReferralsService {
 
     const cleanData = this.removeUndefinedKeys(updateData);
 
-    const changes = diffObjects(
-      existing as unknown as Record<string, unknown>,
-      cleanData,
-      TRACKED_FIELDS,
-    );
+    const changes = diffObjects(existing, cleanData, TRACKED_FIELDS);
 
     const hasStatusChange = changes.some((c) => c.field === 'referralStatus');
 


### PR DESCRIPTION
Remove the VALID_STATUS_TRANSITIONS check and related assigned-to validation in ReferralsService, keeping only the requirement that a referralOutcome is provided when moving to CLOSED. Simplify diffObjects call to pass the existing object directly. Update multiple unit tests in referrals.service.spec.ts to reflect allowed transitions, to assert successful updates, to mock prisma.update responses, and to expect the specific error message when referralOutcome is missing.