### PR TITLE
Add column header menu, filters, and export/query support

### DIFF
--- a/admin-app/src/__tests__/pages/Referrals.test.tsx
+++ b/admin-app/src/__tests__/pages/Referrals.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -63,11 +69,24 @@ function renderReferrals() {
 describe("Referrals page export", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.defineProperty(HTMLDialogElement.prototype, "showModal", {
+      value: vi.fn(),
+      writable: true,
+    });
+    Object.defineProperty(HTMLDialogElement.prototype, "close", {
+      value: vi.fn(),
+      writable: true,
+    });
     mockApiService.fetchReferrals.mockResolvedValue({
       data: [testReferral],
       meta: { total: 1, page: 1, limit: 25, totalPages: 1 },
     });
     mockApiService.fetchAdminColumns.mockResolvedValue([
+      "flag",
+      "createdAt",
+      "individualFirstName",
+    ]);
+    mockApiService.updateAdminColumns.mockResolvedValue([
       "flag",
       "createdAt",
       "individualFirstName",
@@ -87,11 +106,154 @@ describe("Referrals page export", () => {
     renderReferrals();
 
     await screen.findByText("Alice");
-    fireEvent.click(screen.getByRole("button", { name: "Export CSV" }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Export CSV" }));
+    });
 
     expect(
       await screen.findByText(/Exported first 1 of 2 referrals/),
     ).toHaveTextContent("Exported first 1 of 2 referrals");
     expect(mockDownloadCsv).toHaveBeenCalledOnce();
+  });
+
+  it("passes trimmed keyword search to the API", async () => {
+    renderReferrals();
+
+    await screen.findByText("Alice");
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText("Filter by keyword"), {
+        target: { value: "  smith  " },
+      });
+      fireEvent.keyDown(screen.getByPlaceholderText("Filter by keyword"), {
+        key: "Enter",
+      });
+    });
+
+    await waitFor(() =>
+      expect(mockApiService.fetchReferrals).toHaveBeenLastCalledWith(
+        expect.objectContaining({ search: "smith", page: 1 }),
+      ),
+    );
+  });
+
+  it("passes sort params to the API from a column header menu", async () => {
+    renderReferrals();
+
+    await screen.findByText("Alice");
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Open options for First Name"));
+    });
+    await act(async () => {
+      fireEvent.click(await screen.findByText("Z to A"));
+    });
+
+    await waitFor(() =>
+      expect(mockApiService.fetchReferrals).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sortBy: "individualFirstName",
+          sortOrder: "desc",
+          page: 1,
+        }),
+      ),
+    );
+  });
+
+  it("passes filter params to the API from a column header menu", async () => {
+    renderReferrals();
+
+    await screen.findByText("Alice");
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Open options for First Name"));
+    });
+    fireEvent.click(screen.getByText("Filter by"));
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Filter operator" }),
+      {
+        target: { value: "contains" },
+      },
+    );
+    fireEvent.change(screen.getByLabelText("Filter value"), {
+      target: { value: "Ali" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    });
+
+    await waitFor(() =>
+      expect(mockApiService.fetchReferrals).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          filterBy: "individualFirstName",
+          filterOperator: "contains",
+          filterValue: "Ali",
+          page: 1,
+        }),
+      ),
+    );
+  });
+
+  it("requests the next page when pagination advances", async () => {
+    mockApiService.fetchReferrals.mockImplementation(({ page = 1 }) =>
+      Promise.resolve({
+        data: [testReferral],
+        meta: { total: 30, page, limit: 25, totalPages: 2 },
+      }),
+    );
+
+    renderReferrals();
+
+    await screen.findByText("Showing 1–25 of 30");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    });
+
+    await waitFor(() =>
+      expect(mockApiService.fetchReferrals).toHaveBeenLastCalledWith(
+        expect.objectContaining({ page: 2 }),
+      ),
+    );
+    expect(await screen.findByText("Showing 26–30 of 30")).toBeInTheDocument();
+  });
+
+  it("shows an alert when export fails", async () => {
+    mockApiService.fetchReferralsForExport.mockRejectedValue(
+      new Error("Export unavailable"),
+    );
+
+    renderReferrals();
+
+    await screen.findByText("Alice");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Export CSV" }));
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Export unavailable",
+    );
+    expect(mockDownloadCsv).not.toHaveBeenCalled();
+  });
+
+  it("saves selected column settings from the column picker", async () => {
+    renderReferrals();
+
+    await screen.findByText("Alice");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Columns (3)" }));
+    });
+
+    expect(await screen.findByText("Choose columns")).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByText("Save"));
+    });
+
+    await waitFor(() =>
+      expect(mockApiService.updateAdminColumns).toHaveBeenCalledWith([
+        "flag",
+        "createdAt",
+        "individualFirstName",
+      ]),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("Choose columns")).not.toBeInTheDocument(),
+    );
   });
 });

--- a/admin-app/src/__tests__/pages/Referrals.test.tsx
+++ b/admin-app/src/__tests__/pages/Referrals.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Referrals } from "../../pages/Referrals";
+import type { Referral } from "../../types";
+
+const { mockApiService, mockDownloadCsv } = vi.hoisted(() => ({
+  mockApiService: {
+    fetchReferrals: vi.fn(),
+    fetchReferralsForExport: vi.fn(),
+    fetchAdminColumns: vi.fn(),
+    updateAdminColumns: vi.fn(),
+  },
+  mockDownloadCsv: vi.fn(),
+}));
+
+vi.mock("../../services", () => ({
+  apiService: mockApiService,
+}));
+
+vi.mock("../../utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils")>();
+  return {
+    ...actual,
+    downloadCsv: mockDownloadCsv,
+  };
+});
+
+const testReferral = {
+  id: "referral-1",
+  flag: false,
+  referralStatus: "OPEN",
+  referralOutcome: null,
+  referredBy: "SDPR_INTERNAL",
+  referrerContactName: "Test Referrer",
+  individualFirstName: "Alice",
+  individualLastName: "Smith",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  region: { id: "region-1", name: "Vancouver Island" },
+  specificCityTown: "Victoria",
+  assignedTo: null,
+} as Referral;
+
+function renderReferrals() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <Referrals />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("Referrals page export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiService.fetchReferrals.mockResolvedValue({
+      data: [testReferral],
+      meta: { total: 1, page: 1, limit: 25, totalPages: 1 },
+    });
+    mockApiService.fetchAdminColumns.mockResolvedValue([
+      "flag",
+      "createdAt",
+      "individualFirstName",
+    ]);
+    mockApiService.fetchReferralsForExport.mockResolvedValue({
+      data: [testReferral],
+      meta: {
+        total: 2,
+        exported: 1,
+        truncated: true,
+        maxRows: 10000,
+      },
+    });
+  });
+
+  it("shows a warning when an export is truncated", async () => {
+    renderReferrals();
+
+    await screen.findByText("Alice");
+    fireEvent.click(screen.getByRole("button", { name: "Export CSV" }));
+
+    expect(
+      await screen.findByText(/Exported first 1 of 2 referrals/),
+    ).toHaveTextContent("Exported first 1 of 2 referrals");
+    expect(mockDownloadCsv).toHaveBeenCalledOnce();
+  });
+});

--- a/admin-app/src/__tests__/pages/referrals/ColumnFilterPopover.test.tsx
+++ b/admin-app/src/__tests__/pages/referrals/ColumnFilterPopover.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ColumnFilterPopover } from "../../../pages/referrals/ColumnFilterPopover";
+
+function renderPopover(overrides = {}) {
+  const props = {
+    operator: "equals" as const,
+    value: "",
+    showClear: true,
+    onOperatorChange: vi.fn(),
+    onValueChange: vi.fn(),
+    onApply: vi.fn(),
+    onClear: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+
+  render(<ColumnFilterPopover {...props} />);
+  return props;
+}
+
+describe("ColumnFilterPopover", () => {
+  it("renders accessible filter controls", () => {
+    renderPopover();
+
+    expect(
+      screen.getByRole("combobox", { name: "Filter operator" }),
+    ).toHaveValue("equals");
+    expect(screen.getByLabelText("Filter value")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Close filter" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls change handlers for operator and value updates", () => {
+    const props = renderPopover();
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "contains" },
+    });
+    fireEvent.change(screen.getByLabelText("Filter value"), {
+      target: { value: "smith" },
+    });
+
+    expect(props.onOperatorChange).toHaveBeenCalledWith("contains");
+    expect(props.onValueChange).toHaveBeenCalledWith("smith");
+  });
+
+  it("disables apply for blank values", () => {
+    const blankProps = renderPopover({ value: "   " });
+
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+    fireEvent.keyDown(screen.getByLabelText("Filter value"), { key: "Enter" });
+    expect(blankProps.onApply).not.toHaveBeenCalled();
+  });
+
+  it("applies with Enter when the filter value is valid", () => {
+    const props = renderPopover({ value: "smith" });
+
+    fireEvent.keyDown(screen.getByLabelText("Filter value"), { key: "Enter" });
+
+    expect(props.onApply).toHaveBeenCalledOnce();
+  });
+
+  it("applies, clears, and closes through button actions", () => {
+    const props = renderPopover({ value: "smith" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close filter" }));
+    fireEvent.keyDown(screen.getByLabelText("Filter value"), { key: "Enter" });
+
+    expect(props.onApply).toHaveBeenCalledTimes(2);
+    expect(props.onClear).toHaveBeenCalledOnce();
+    expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("hides the clear action when no active filter exists", () => {
+    renderPopover({ showClear: false });
+
+    expect(
+      screen.queryByRole("button", { name: "Clear" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/admin-app/src/__tests__/pages/referrals/ColumnFilterPopover.test.tsx
+++ b/admin-app/src/__tests__/pages/referrals/ColumnFilterPopover.test.tsx
@@ -82,4 +82,66 @@ describe("ColumnFilterPopover", () => {
       screen.queryByRole("button", { name: "Clear" }),
     ).not.toBeInTheDocument();
   });
+
+  it("hides the contains option when equalsOnly is true", () => {
+    renderPopover({ equalsOnly: true });
+
+    const select = screen.getByRole("combobox", { name: "Filter operator" });
+    expect(select).toHaveValue("equals");
+    expect(
+      screen.queryByRole("option", { name: "Contains" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Equals" })).toBeInTheDocument();
+  });
+
+  it("shows the contains option when equalsOnly is false", () => {
+    renderPopover({ equalsOnly: false });
+
+    expect(
+      screen.getByRole("option", { name: "Contains" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a date input for date columns", () => {
+    renderPopover({ columnType: "date" });
+
+    const input = screen.getByLabelText("Filter value");
+    expect(input).toHaveAttribute("type", "date");
+    expect(
+      screen.queryByRole("option", { name: "Contains" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a number input for number columns", () => {
+    renderPopover({ columnType: "number" });
+
+    const input = screen.getByLabelText("Filter value");
+    expect(input).toHaveAttribute("type", "number");
+  });
+
+  it("renders a Yes/No select and hides operator for boolean columns", () => {
+    renderPopover({ columnType: "boolean" });
+
+    expect(
+      screen.queryByRole("combobox", { name: "Filter operator" }),
+    ).not.toBeInTheDocument();
+    const valueSelect = screen.getByRole("combobox", { name: "Filter value" });
+    expect(screen.getByRole("option", { name: "Yes" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "No" })).toBeInTheDocument();
+    expect(valueSelect).toHaveValue("");
+  });
+
+  it("enables apply when a boolean value is selected", () => {
+    const props = renderPopover({ columnType: "boolean", value: "yes" });
+
+    expect(screen.getByRole("button", { name: "Apply" })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    expect(props.onApply).toHaveBeenCalledOnce();
+  });
+
+  it("disables apply when no boolean value is selected", () => {
+    renderPopover({ columnType: "boolean", value: "" });
+
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+  });
 });

--- a/admin-app/src/__tests__/pages/referrals/ColumnHeaderMenu.test.tsx
+++ b/admin-app/src/__tests__/pages/referrals/ColumnHeaderMenu.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ColumnHeaderMenu } from "../../../pages/referrals/ColumnHeaderMenu";
 
@@ -50,5 +50,20 @@ describe("ColumnHeaderMenu", () => {
 
     expect(screen.getByLabelText("Filter value")).toBeInTheDocument();
     expect(props.onSort).not.toHaveBeenCalled();
+  });
+
+  it("returns focus to the trigger when Escape closes the menu", async () => {
+    const props = renderMenu();
+    const trigger = screen.getByLabelText("Open options for Last Name");
+    const outsideButton = document.createElement("button");
+    document.body.appendChild(outsideButton);
+    outsideButton.focus();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(props.onClose).toHaveBeenCalledOnce();
+    await waitFor(() => expect(trigger).toHaveFocus());
+
+    outsideButton.remove();
   });
 });

--- a/admin-app/src/__tests__/pages/referrals/ColumnHeaderMenu.test.tsx
+++ b/admin-app/src/__tests__/pages/referrals/ColumnHeaderMenu.test.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps, useState } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ColumnHeaderMenu } from "../../../pages/referrals/ColumnHeaderMenu";
@@ -23,6 +24,35 @@ function renderMenu(overrides = {}) {
 
   render(<ColumnHeaderMenu {...props} />);
   return props;
+}
+
+function ControlledMenu(
+  overrides: Partial<ComponentProps<typeof ColumnHeaderMenu>> = {},
+) {
+  const [isOpen, setIsOpen] = useState(false);
+  const props = {
+    columnKey: "individualLastName",
+    label: "Last Name",
+    sortBy: undefined,
+    sortOrder: undefined,
+    activeFilterBy: undefined,
+    activeFilterOperator: undefined,
+    activeFilterValue: undefined,
+    sortable: true,
+    onSort: vi.fn(),
+    onApplyFilter: vi.fn(),
+    onClearFilter: vi.fn(),
+    ...overrides,
+  };
+
+  return (
+    <ColumnHeaderMenu
+      {...props}
+      isOpen={isOpen}
+      onOpen={() => setIsOpen(true)}
+      onClose={() => setIsOpen(false)}
+    />
+  );
 }
 
 describe("ColumnHeaderMenu", () => {
@@ -65,5 +95,49 @@ describe("ColumnHeaderMenu", () => {
     await waitFor(() => expect(trigger).toHaveFocus());
 
     outsideButton.remove();
+  });
+
+  it("closes when clicking outside the trigger and menu", () => {
+    const props = renderMenu();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("prefills filter drafts only for the active filter column", () => {
+    render(
+      <ControlledMenu
+        activeFilterBy="region"
+        activeFilterOperator="contains"
+        activeFilterValue="Island"
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Open options for Last Name"));
+    fireEvent.click(screen.getByText("Filter by"));
+
+    expect(
+      screen.getByRole("combobox", { name: "Filter operator" }),
+    ).toHaveValue("equals");
+    expect(screen.getByLabelText("Filter value")).toHaveValue("");
+  });
+
+  it("prefills filter drafts for the current active filter column", () => {
+    render(
+      <ControlledMenu
+        activeFilterBy="individualLastName"
+        activeFilterOperator="contains"
+        activeFilterValue="Smith"
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Open options for Last Name"));
+    fireEvent.click(screen.getByText("Filter by"));
+
+    expect(
+      screen.getByRole("combobox", { name: "Filter operator" }),
+    ).toHaveValue("contains");
+    expect(screen.getByLabelText("Filter value")).toHaveValue("Smith");
   });
 });

--- a/admin-app/src/__tests__/pages/referrals/ColumnHeaderMenu.test.tsx
+++ b/admin-app/src/__tests__/pages/referrals/ColumnHeaderMenu.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ColumnHeaderMenu } from "../../../pages/referrals/ColumnHeaderMenu";
+
+function renderMenu(overrides = {}) {
+  const props = {
+    columnKey: "individualLastName",
+    label: "Last Name",
+    isOpen: true,
+    sortBy: undefined,
+    sortOrder: undefined,
+    activeFilterBy: undefined,
+    activeFilterOperator: undefined,
+    activeFilterValue: undefined,
+    sortable: true,
+    onOpen: vi.fn(),
+    onClose: vi.fn(),
+    onSort: vi.fn(),
+    onApplyFilter: vi.fn(),
+    onClearFilter: vi.fn(),
+    ...overrides,
+  };
+
+  render(<ColumnHeaderMenu {...props} />);
+  return props;
+}
+
+describe("ColumnHeaderMenu", () => {
+  it("calls sort handlers for sortable columns", () => {
+    const props = renderMenu();
+
+    fireEvent.click(screen.getByText("A to Z"));
+
+    expect(props.onSort).toHaveBeenCalledWith("asc");
+    expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("hides sort actions for non-sortable columns", () => {
+    const props = renderMenu({
+      columnKey: "neededSupports",
+      label: "Needed Supports",
+      sortable: false,
+    });
+
+    expect(screen.queryByText("A to Z")).not.toBeInTheDocument();
+    expect(screen.queryByText("Z to A")).not.toBeInTheDocument();
+    expect(screen.getByText("Filter by")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Filter by"));
+
+    expect(screen.getByLabelText("Filter value")).toBeInTheDocument();
+    expect(props.onSort).not.toHaveBeenCalled();
+  });
+});

--- a/admin-app/src/__tests__/services/api.service.test.ts
+++ b/admin-app/src/__tests__/services/api.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { UserRole } from "../../types";
 
 // Mock the auth module before importing api service
 const mockKeycloak = {
@@ -91,6 +92,38 @@ describe("APIService methods", () => {
       // Assert
       expect(mockGet).toHaveBeenCalledWith("/referrals", {
         params: { page: 1, limit: 25, search: "Jane" },
+      });
+      expect(result).toEqual(mockData);
+    });
+
+    it("should fetch referrals for export with metadata", async () => {
+      // Arrange
+      const mockData = {
+        data: [{ id: "1" }],
+        meta: {
+          total: 2,
+          exported: 1,
+          truncated: true,
+          maxRows: 10000,
+        },
+      };
+      mockGet.mockResolvedValue({ data: mockData });
+      const { apiService } = await import("../../services/api");
+
+      // Act
+      const result = await apiService.fetchReferralsForExport({
+        search: "Jane",
+        sortBy: "createdAt",
+        sortOrder: "desc",
+      });
+
+      // Assert
+      expect(mockGet).toHaveBeenCalledWith("/referrals/export", {
+        params: {
+          search: "Jane",
+          sortBy: "createdAt",
+          sortOrder: "desc",
+        },
       });
       expect(result).toEqual(mockData);
     });
@@ -335,7 +368,7 @@ describe("APIService methods", () => {
       const { apiService } = await import("../../services/api");
 
       // Act
-      const result = await apiService.fetchUsers("ADMIN" as never);
+      const result = await apiService.fetchUsers(UserRole.ADMIN);
 
       // Assert
       expect(mockGet).toHaveBeenCalledWith("/users", {

--- a/admin-app/src/pages/Referrals.tsx
+++ b/admin-app/src/pages/Referrals.tsx
@@ -120,20 +120,10 @@ export function Referrals() {
   const canPrev = page > 1;
   const canNext = page < totalPages;
 
-  if (isLoading) {
+  if (isLoading && !data) {
     return (
       <div className="flex items-center justify-center h-full">
         <p>Loading referrals...</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <p className="text-red-600">
-          Error loading referrals. Please try again.
-        </p>
       </div>
     );
   }
@@ -196,6 +186,15 @@ export function Referrals() {
           className="px-4 sm:px-6 py-2 bg-red-50 border-b border-red-200 text-sm text-red-700"
         >
           {exportError}
+        </div>
+      ) : null}
+
+      {error ? (
+        <div
+          role="alert"
+          className="px-4 sm:px-6 py-2 bg-red-50 border-b border-red-200 text-sm text-red-700"
+        >
+          Error loading referrals. Please adjust your filters and try again.
         </div>
       ) : null}
 

--- a/admin-app/src/pages/Referrals.tsx
+++ b/admin-app/src/pages/Referrals.tsx
@@ -8,8 +8,14 @@ import {
 } from "@tanstack/react-query";
 import { apiService } from "../services";
 import { toCsv, downloadCsv } from "../utils";
-import type { Referral } from "../types";
+import type {
+  FetchReferralsParams,
+  Referral,
+  FilterOperator,
+  SortOrder,
+} from "../types";
 import { ColumnPicker } from "./referrals/ColumnPicker";
+import { ColumnHeaderMenu } from "./referrals/ColumnHeaderMenu";
 import { resolveColumns } from "./referrals/columns";
 
 const PAGE_SIZE = 25;
@@ -28,20 +34,36 @@ export function Referrals() {
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
   const [activeSearch, setActiveSearch] = useState("");
+  const [sortBy, setSortBy] = useState<string | undefined>(undefined);
+  const [sortOrder, setSortOrder] = useState<SortOrder | undefined>(undefined);
+  const [filterBy, setFilterBy] = useState<string | undefined>(undefined);
+  const [filterOperator, setFilterOperator] =
+    useState<FilterOperator>("equals");
+  const [filterValue, setFilterValue] = useState("");
+  const [openMenuColumnKey, setOpenMenuColumnKey] = useState<string | null>(
+    null,
+  );
   const [pickerOpen, setPickerOpen] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+  const [exportWarning, setExportWarning] = useState<string | null>(null);
+
+  const activeFilterValue =
+    filterBy && filterValue.trim() ? filterValue.trim() : undefined;
+
+  const referralQueryParams: FetchReferralsParams = {
+    page,
+    limit: PAGE_SIZE,
+    search: activeSearch || undefined,
+    sortBy,
+    sortOrder,
+    filterBy,
+    filterOperator: activeFilterValue ? filterOperator : undefined,
+    filterValue: activeFilterValue,
+  };
 
   const { data, isLoading, error } = useQuery({
-    queryKey: [
-      "referrals",
-      { page, limit: PAGE_SIZE, search: activeSearch || undefined },
-    ],
-    queryFn: () =>
-      apiService.fetchReferrals({
-        page,
-        limit: PAGE_SIZE,
-        search: activeSearch || undefined,
-      }),
+    queryKey: ["referrals", referralQueryParams],
+    queryFn: () => apiService.fetchReferrals(referralQueryParams),
     placeholderData: keepPreviousData,
   });
 
@@ -62,7 +84,9 @@ export function Referrals() {
 
   const exportMutation = useMutation({
     mutationFn: async () => {
-      const all = await apiService.fetchReferralsForExport();
+      const result =
+        await apiService.fetchReferralsForExport(referralQueryParams);
+      const all = result.data;
       const headers = columns.map((c) => c.label);
       const rows = all.map((r: Referral) =>
         columns.map((c) => {
@@ -71,13 +95,22 @@ export function Referrals() {
         }),
       );
       downloadCsv(buildExportFilename(), toCsv(headers, rows));
+      return result.meta;
     },
     onError: (err: unknown) => {
       const message =
         err instanceof Error ? err.message : "Failed to export referrals.";
       setExportError(message);
+      setExportWarning(null);
     },
-    onSuccess: () => setExportError(null),
+    onSuccess: (meta) => {
+      setExportError(null);
+      setExportWarning(
+        meta.truncated
+          ? `Exported first ${meta.exported.toLocaleString()} of ${meta.total.toLocaleString()} referrals. Narrow filters to export the full result set.`
+          : null,
+      );
+    },
   });
 
   const referrals = data?.data ?? [];
@@ -166,6 +199,15 @@ export function Referrals() {
         </div>
       ) : null}
 
+      {exportWarning ? (
+        <div
+          aria-live="polite"
+          className="block px-4 sm:px-6 py-2 bg-yellow-50 border-b border-yellow-200 text-sm text-yellow-800"
+        >
+          {exportWarning}
+        </div>
+      ) : null}
+
       <div className="flex-1 overflow-auto bg-white">
         <table className="border-collapse text-sm table-fixed min-w-full">
           <thead>
@@ -176,9 +218,40 @@ export function Referrals() {
               {columns.map((col) => (
                 <th
                   key={col.key}
-                  className={`${col.width} p-3 text-left border-b border-gray-200 bg-gray-100 font-semibold text-bcgov-gray-dark sticky top-0 z-10 overflow-hidden text-ellipsis whitespace-nowrap`}
+                  className={`${col.width} p-3 text-left border-b border-gray-200 bg-gray-100 font-semibold text-bcgov-gray-dark sticky top-0 z-10 whitespace-nowrap`}
                 >
-                  {col.label}
+                  <ColumnHeaderMenu
+                    columnKey={col.key}
+                    label={col.label}
+                    isOpen={openMenuColumnKey === col.key}
+                    sortBy={sortBy}
+                    sortOrder={sortOrder}
+                    activeFilterBy={filterBy}
+                    activeFilterOperator={filterOperator}
+                    activeFilterValue={filterValue}
+                    sortable={col.sortable !== false}
+                    onOpen={() => setOpenMenuColumnKey(col.key)}
+                    onClose={() => setOpenMenuColumnKey(null)}
+                    onSort={(order) => {
+                      setSortBy(col.key);
+                      setSortOrder(order);
+                      setPage(1);
+                    }}
+                    onApplyFilter={(operator, value) => {
+                      setFilterBy(col.key);
+                      setFilterOperator(operator);
+                      setFilterValue(value);
+                      setPage(1);
+                    }}
+                    onClearFilter={() => {
+                      if (filterBy === col.key) {
+                        setFilterBy(undefined);
+                        setFilterOperator("equals");
+                        setFilterValue("");
+                        setPage(1);
+                      }
+                    }}
+                  />
                 </th>
               ))}
             </tr>

--- a/admin-app/src/pages/Referrals.tsx
+++ b/admin-app/src/pages/Referrals.tsx
@@ -272,7 +272,11 @@ export function Referrals() {
                   key={referral.id}
                   className="cursor-pointer hover:bg-blue-50"
                   onClick={(e) => {
-                    if ((e.target as HTMLElement).tagName !== "INPUT") {
+                    const target = e.target;
+                    if (
+                      !(target instanceof HTMLElement) ||
+                      target.tagName !== "INPUT"
+                    ) {
                       navigate(`/referrals/${referral.id}`);
                     }
                   }}

--- a/admin-app/src/pages/referrals/ColumnFilterPopover.tsx
+++ b/admin-app/src/pages/referrals/ColumnFilterPopover.tsx
@@ -1,0 +1,85 @@
+import type { FilterOperator } from "../../types";
+
+interface ColumnFilterPopoverProps {
+  operator: FilterOperator;
+  value: string;
+  showClear: boolean;
+  onOperatorChange: (operator: FilterOperator) => void;
+  onValueChange: (value: string) => void;
+  onApply: () => void;
+  onClear: () => void;
+  onClose: () => void;
+}
+
+export function ColumnFilterPopover({
+  operator,
+  value,
+  showClear,
+  onOperatorChange,
+  onValueChange,
+  onApply,
+  onClear,
+  onClose,
+}: Readonly<ColumnFilterPopoverProps>) {
+  return (
+    <div className="w-64 max-w-full rounded border border-bcgov-border bg-white p-4 shadow-xl">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="m-0 text-lg font-bold text-bcgov-gray-dark">
+          Filter by
+        </h3>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xl leading-none text-bcgov-gray hover:text-bcgov-gray-dark"
+          aria-label="Close filter"
+        >
+          &#x2715;
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        <select
+          className="w-full rounded border border-bcgov-border bg-white px-3 py-2 text-sm text-bcgov-gray-dark"
+          value={operator}
+          onChange={(e) => onOperatorChange(e.target.value as FilterOperator)}
+        >
+          <option value="equals">Equals</option>
+          <option value="contains">Contains</option>
+        </select>
+
+        <input
+          type="text"
+          className="w-full rounded border border-bcgov-border bg-white px-3 py-2 text-sm text-bcgov-gray-dark"
+          value={value}
+          onChange={(e) => onValueChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && value.trim()) {
+              onApply();
+            }
+          }}
+          aria-label="Filter value"
+        />
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onApply}
+            disabled={!value.trim()}
+            className="rounded bg-bcgov-blue px-4 py-2 text-sm text-white hover:bg-bcgov-blue-dark disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Apply
+          </button>
+          {showClear ? (
+            <button
+              type="button"
+              onClick={onClear}
+              className="rounded border border-bcgov-border bg-white px-4 py-2 text-sm text-bcgov-gray hover:bg-bcgov-gray-light"
+            >
+              Clear
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/admin-app/src/pages/referrals/ColumnFilterPopover.tsx
+++ b/admin-app/src/pages/referrals/ColumnFilterPopover.tsx
@@ -33,7 +33,7 @@ export function ColumnFilterPopover({
           className="text-xl leading-none text-bcgov-gray hover:text-bcgov-gray-dark"
           aria-label="Close filter"
         >
-          &#x2715;
+          <span aria-hidden="true">&#x2715;</span>
         </button>
       </div>
 

--- a/admin-app/src/pages/referrals/ColumnFilterPopover.tsx
+++ b/admin-app/src/pages/referrals/ColumnFilterPopover.tsx
@@ -40,6 +40,7 @@ export function ColumnFilterPopover({
       <div className="space-y-3">
         <select
           className="w-full rounded border border-bcgov-border bg-white px-3 py-2 text-sm text-bcgov-gray-dark"
+          aria-label="Filter operator"
           value={operator}
           onChange={(e) => onOperatorChange(e.target.value as FilterOperator)}
         >

--- a/admin-app/src/pages/referrals/ColumnFilterPopover.tsx
+++ b/admin-app/src/pages/referrals/ColumnFilterPopover.tsx
@@ -1,9 +1,13 @@
 import type { FilterOperator } from "../../types";
 
+export type ColumnFilterType = "text" | "date" | "number" | "boolean";
+
 interface ColumnFilterPopoverProps {
   operator: FilterOperator;
   value: string;
   showClear: boolean;
+  equalsOnly?: boolean;
+  columnType?: ColumnFilterType;
   onOperatorChange: (operator: FilterOperator) => void;
   onValueChange: (value: string) => void;
   onApply: () => void;
@@ -11,10 +15,20 @@ interface ColumnFilterPopoverProps {
   onClose: () => void;
 }
 
+function resolveInputType(
+  columnType: ColumnFilterType,
+): "text" | "date" | "number" {
+  if (columnType === "date") return "date";
+  if (columnType === "number") return "number";
+  return "text";
+}
+
 export function ColumnFilterPopover({
   operator,
   value,
   showClear,
+  equalsOnly = false,
+  columnType = "text",
   onOperatorChange,
   onValueChange,
   onApply,
@@ -38,28 +52,45 @@ export function ColumnFilterPopover({
       </div>
 
       <div className="space-y-3">
-        <select
-          className="w-full rounded border border-bcgov-border bg-white px-3 py-2 text-sm text-bcgov-gray-dark"
-          aria-label="Filter operator"
-          value={operator}
-          onChange={(e) => onOperatorChange(e.target.value as FilterOperator)}
-        >
-          <option value="equals">Equals</option>
-          <option value="contains">Contains</option>
-        </select>
+        {columnType !== "boolean" && (
+          <select
+            className="w-full rounded border border-bcgov-border bg-white px-3 py-2 text-sm text-bcgov-gray-dark"
+            aria-label="Filter operator"
+            value={operator}
+            onChange={(e) => onOperatorChange(e.target.value as FilterOperator)}
+          >
+            <option value="equals">Equals</option>
+            {columnType === "text" && !equalsOnly && (
+              <option value="contains">Contains</option>
+            )}
+          </select>
+        )}
 
-        <input
-          type="text"
-          className="w-full rounded border border-bcgov-border bg-white px-3 py-2 text-sm text-bcgov-gray-dark"
-          value={value}
-          onChange={(e) => onValueChange(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && value.trim()) {
-              onApply();
-            }
-          }}
-          aria-label="Filter value"
-        />
+        {columnType === "boolean" ? (
+          <select
+            className="w-full rounded border border-bcgov-border bg-white px-3 py-2 text-sm text-bcgov-gray-dark"
+            aria-label="Filter value"
+            value={value}
+            onChange={(e) => onValueChange(e.target.value)}
+          >
+            <option value="">— Select —</option>
+            <option value="yes">Yes</option>
+            <option value="no">No</option>
+          </select>
+        ) : (
+          <input
+            type={resolveInputType(columnType)}
+            className="w-full rounded border border-bcgov-border bg-white px-3 py-2 text-sm text-bcgov-gray-dark"
+            value={value}
+            onChange={(e) => onValueChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && value.trim()) {
+                onApply();
+              }
+            }}
+            aria-label="Filter value"
+          />
+        )}
 
         <div className="flex items-center gap-2">
           <button

--- a/admin-app/src/pages/referrals/ColumnHeaderMenu.tsx
+++ b/admin-app/src/pages/referrals/ColumnHeaderMenu.tsx
@@ -148,6 +148,7 @@ export function ColumnHeaderMenu({
     const onEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         onClose();
+        setTimeout(() => triggerRef.current?.focus(), 0);
       }
     };
 

--- a/admin-app/src/pages/referrals/ColumnHeaderMenu.tsx
+++ b/admin-app/src/pages/referrals/ColumnHeaderMenu.tsx
@@ -1,0 +1,280 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { FilterOperator, SortOrder } from "../../types";
+import { ColumnFilterPopover } from "./ColumnFilterPopover";
+
+const DROPDOWN_OFFSET = 4;
+const VIEWPORT_PADDING = 8;
+
+const DATE_SORT_KEYS = new Set([
+  "createdAt",
+  "updatedAt",
+  "individualDateOfBirth",
+  "releaseDate",
+  "assignedOn",
+  "firstContactMadeOn",
+  "followUpDate",
+  "dueDate",
+  "completedDate",
+]);
+
+const NUMERIC_SORT_KEYS = new Set(["lottTriage", "lottContact"]);
+const BOOLEAN_SORT_KEYS = new Set(["flag"]);
+
+function getSortLabels(columnKey: string): { asc: string; desc: string } {
+  if (DATE_SORT_KEYS.has(columnKey)) {
+    return { asc: "Oldest to Newest", desc: "Newest to Oldest" };
+  }
+  if (NUMERIC_SORT_KEYS.has(columnKey)) {
+    return { asc: "Lowest to Highest", desc: "Highest to Lowest" };
+  }
+  if (BOOLEAN_SORT_KEYS.has(columnKey)) {
+    return { asc: "No to Yes", desc: "Yes to No" };
+  }
+  return { asc: "A to Z", desc: "Z to A" };
+}
+
+interface ColumnHeaderMenuProps {
+  columnKey: string;
+  label: string;
+  isOpen: boolean;
+  sortBy?: string;
+  sortOrder?: SortOrder;
+  activeFilterBy?: string;
+  activeFilterOperator?: FilterOperator;
+  activeFilterValue?: string;
+  sortable?: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  onSort: (order: SortOrder) => void;
+  onApplyFilter: (operator: FilterOperator, value: string) => void;
+  onClearFilter: () => void;
+}
+
+export function ColumnHeaderMenu({
+  columnKey,
+  label,
+  isOpen,
+  sortBy,
+  sortOrder,
+  activeFilterBy,
+  activeFilterOperator,
+  activeFilterValue,
+  sortable = true,
+  onOpen,
+  onClose,
+  onSort,
+  onApplyFilter,
+  onClearFilter,
+}: Readonly<ColumnHeaderMenuProps>) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const [showFilterPopover, setShowFilterPopover] = useState(false);
+  const [dropdownTop, setDropdownTop] = useState(0);
+  const [dropdownLeft, setDropdownLeft] = useState(0);
+  const [draftOperator, setDraftOperator] = useState<FilterOperator>("equals");
+  const [draftValue, setDraftValue] = useState("");
+
+  useLayoutEffect(() => {
+    if (!isOpen || !dropdownRef.current || !triggerRef.current) {
+      return;
+    }
+
+    const updatePosition = () => {
+      if (!dropdownRef.current || !triggerRef.current) {
+        return;
+      }
+
+      const triggerRect = triggerRef.current.getBoundingClientRect();
+      const dropdownRect = dropdownRef.current.getBoundingClientRect();
+
+      let nextLeft = triggerRect.left;
+      if (
+        nextLeft + dropdownRect.width >
+        window.innerWidth - VIEWPORT_PADDING
+      ) {
+        nextLeft = window.innerWidth - VIEWPORT_PADDING - dropdownRect.width;
+      }
+      if (nextLeft < VIEWPORT_PADDING) {
+        nextLeft = VIEWPORT_PADDING;
+      }
+
+      let nextTop = triggerRect.bottom + DROPDOWN_OFFSET;
+      if (
+        nextTop + dropdownRect.height >
+        window.innerHeight - VIEWPORT_PADDING
+      ) {
+        nextTop = Math.max(
+          VIEWPORT_PADDING,
+          triggerRect.top - dropdownRect.height - DROPDOWN_OFFSET,
+        );
+      }
+
+      setDropdownLeft((current) => (current === nextLeft ? current : nextLeft));
+      setDropdownTop((current) => (current === nextTop ? current : nextTop));
+    };
+
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [isOpen, showFilterPopover]);
+
+  const isSorted = sortBy === columnKey;
+  const sortLabels = getSortLabels(columnKey);
+  const hasActiveFilter =
+    activeFilterBy === columnKey && Boolean(activeFilterValue?.trim());
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const onPointerDown = (event: MouseEvent) => {
+      if (
+        rootRef.current?.contains(event.target as Node) ||
+        dropdownRef.current?.contains(event.target as Node)
+      ) {
+        return;
+      }
+      onClose();
+    };
+
+    const onEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onEscape);
+
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onEscape);
+    };
+  }, [isOpen, onClose]);
+
+  const dropdownContent = (
+    <div
+      ref={dropdownRef}
+      className="fixed z-30"
+      style={{
+        top: dropdownTop,
+        left: dropdownLeft,
+        maxWidth: `calc(100vw - ${VIEWPORT_PADDING * 2}px)`,
+      }}
+    >
+      {showFilterPopover ? (
+        <ColumnFilterPopover
+          operator={draftOperator}
+          value={draftValue}
+          showClear={hasActiveFilter}
+          onOperatorChange={setDraftOperator}
+          onValueChange={setDraftValue}
+          onApply={() => {
+            onApplyFilter(draftOperator, draftValue.trim());
+            onClose();
+          }}
+          onClear={() => {
+            onClearFilter();
+            onClose();
+          }}
+          onClose={onClose}
+        />
+      ) : (
+        <div className="w-48 max-w-full rounded border border-bcgov-border bg-white py-1 shadow-xl">
+          {sortable ? (
+            <>
+              <button
+                type="button"
+                onClick={() => {
+                  onSort("asc");
+                  onClose();
+                }}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-bcgov-gray-dark hover:bg-bcgov-gray-light"
+              >
+                <span aria-hidden="true">↑</span>
+                <span>{sortLabels.asc}</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  onSort("desc");
+                  onClose();
+                }}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-bcgov-gray-dark hover:bg-bcgov-gray-light"
+              >
+                <span aria-hidden="true">↓</span>
+                <span>{sortLabels.desc}</span>
+              </button>
+              <div className="my-1 border-t border-bcgov-border" />
+            </>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => setShowFilterPopover(true)}
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-bcgov-gray-dark hover:bg-bcgov-gray-light"
+          >
+            <span>Filter by</span>
+          </button>
+          {hasActiveFilter ? (
+            <button
+              type="button"
+              onClick={() => {
+                onClearFilter();
+                onClose();
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-bcgov-gray-dark hover:bg-bcgov-gray-light"
+            >
+              <span>Clear filter</span>
+            </button>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div ref={rootRef} className="relative flex items-center gap-1">
+      <span>{label}</span>
+      {sortable && isSorted ? (
+        <span aria-hidden="true" className="text-xs text-bcgov-blue">
+          {sortOrder === "asc" ? "↑" : "↓"}
+        </span>
+      ) : null}
+      {hasActiveFilter ? (
+        <span aria-hidden="true" className="text-xs text-bcgov-blue">
+          ●
+        </span>
+      ) : null}
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => {
+          if (isOpen) {
+            onClose();
+          } else {
+            setShowFilterPopover(false);
+            setDraftOperator(activeFilterOperator ?? "equals");
+            setDraftValue(activeFilterValue ?? "");
+            onOpen();
+          }
+        }}
+        className="rounded p-0.5 text-bcgov-gray-dark hover:bg-bcgov-gray-light"
+        aria-label={`Open options for ${label}`}
+      >
+        <span aria-hidden="true" className="text-xs">
+          &#x25BE;
+        </span>
+      </button>
+
+      {isOpen ? createPortal(dropdownContent, document.body) : null}
+    </div>
+  );
+}

--- a/admin-app/src/pages/referrals/ColumnHeaderMenu.tsx
+++ b/admin-app/src/pages/referrals/ColumnHeaderMenu.tsx
@@ -136,9 +136,14 @@ export function ColumnHeaderMenu({
     }
 
     const onPointerDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+
       if (
-        rootRef.current?.contains(event.target as Node) ||
-        dropdownRef.current?.contains(event.target as Node)
+        rootRef.current?.contains(target) ||
+        dropdownRef.current?.contains(target)
       ) {
         return;
       }

--- a/admin-app/src/pages/referrals/ColumnHeaderMenu.tsx
+++ b/admin-app/src/pages/referrals/ColumnHeaderMenu.tsx
@@ -260,9 +260,16 @@ export function ColumnHeaderMenu({
           if (isOpen) {
             onClose();
           } else {
+            const isActiveFilterForColumn = activeFilterBy === columnKey;
             setShowFilterPopover(false);
-            setDraftOperator(activeFilterOperator ?? "equals");
-            setDraftValue(activeFilterValue ?? "");
+            setDraftOperator(
+              isActiveFilterForColumn
+                ? (activeFilterOperator ?? "equals")
+                : "equals",
+            );
+            setDraftValue(
+              isActiveFilterForColumn ? (activeFilterValue ?? "") : "",
+            );
             onOpen();
           }
         }}

--- a/admin-app/src/pages/referrals/ColumnHeaderMenu.tsx
+++ b/admin-app/src/pages/referrals/ColumnHeaderMenu.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { FilterOperator, SortOrder } from "../../types";
 import { ColumnFilterPopover } from "./ColumnFilterPopover";
+import type { ColumnFilterType } from "./ColumnFilterPopover";
 
 const DROPDOWN_OFFSET = 4;
 const VIEWPORT_PADDING = 8;
@@ -20,6 +21,22 @@ const DATE_SORT_KEYS = new Set([
 
 const NUMERIC_SORT_KEYS = new Set(["lottTriage", "lottContact"]);
 const BOOLEAN_SORT_KEYS = new Set(["flag"]);
+
+// Columns whose backend filter only accepts 'equals' — mirrors
+// EQUALS_ONLY_FILTER_COLUMN_KEYS in referrals-query.builder.ts.
+const EQUALS_ONLY_FILTER_KEYS = new Set([
+  "flag",
+  "lottTriage",
+  "lottContact",
+  ...DATE_SORT_KEYS,
+]);
+
+function getColumnFilterType(columnKey: string): ColumnFilterType {
+  if (DATE_SORT_KEYS.has(columnKey)) return "date";
+  if (NUMERIC_SORT_KEYS.has(columnKey)) return "number";
+  if (BOOLEAN_SORT_KEYS.has(columnKey)) return "boolean";
+  return "text";
+}
 
 function getSortLabels(columnKey: string): { asc: string; desc: string } {
   if (DATE_SORT_KEYS.has(columnKey)) {
@@ -127,6 +144,8 @@ export function ColumnHeaderMenu({
 
   const isSorted = sortBy === columnKey;
   const sortLabels = getSortLabels(columnKey);
+  const columnType = getColumnFilterType(columnKey);
+  const equalsOnly = EQUALS_ONLY_FILTER_KEYS.has(columnKey);
   const hasActiveFilter =
     activeFilterBy === columnKey && Boolean(activeFilterValue?.trim());
 
@@ -181,10 +200,15 @@ export function ColumnHeaderMenu({
           operator={draftOperator}
           value={draftValue}
           showClear={hasActiveFilter}
+          equalsOnly={equalsOnly}
+          columnType={columnType}
           onOperatorChange={setDraftOperator}
           onValueChange={setDraftValue}
           onApply={() => {
-            onApplyFilter(draftOperator, draftValue.trim());
+            onApplyFilter(
+              equalsOnly ? "equals" : draftOperator,
+              draftValue.trim(),
+            );
             onClose();
           }}
           onClear={() => {
@@ -268,11 +292,10 @@ export function ColumnHeaderMenu({
           } else {
             const isActiveFilterForColumn = activeFilterBy === columnKey;
             setShowFilterPopover(false);
-            setDraftOperator(
-              isActiveFilterForColumn
-                ? (activeFilterOperator ?? "equals")
-                : "equals",
-            );
+            const restoredOperator = isActiveFilterForColumn
+              ? (activeFilterOperator ?? "equals")
+              : "equals";
+            setDraftOperator(equalsOnly ? "equals" : restoredOperator);
             setDraftValue(
               isActiveFilterForColumn ? (activeFilterValue ?? "") : "",
             );

--- a/admin-app/src/pages/referrals/columns.ts
+++ b/admin-app/src/pages/referrals/columns.ts
@@ -13,6 +13,7 @@ export interface ReferralColumn {
   key: string;
   label: string;
   width: string;
+  sortable?: boolean;
   render: (referral: Referral) => string;
 }
 
@@ -214,6 +215,7 @@ export const REFERRAL_COLUMNS: ReferralColumn[] = [
     key: "currentlyConnectedSupports",
     label: "Currently Connected Supports",
     width: "w-[260px]",
+    sortable: false,
     render: (r) => supportsOf(r.currentlyConnectedSupports),
   },
   {
@@ -226,6 +228,7 @@ export const REFERRAL_COLUMNS: ReferralColumn[] = [
     key: "neededSupports",
     label: "Needed Supports",
     width: "w-[260px]",
+    sortable: false,
     render: (r) => supportsOf(r.neededSupports),
   },
   {

--- a/admin-app/src/services/api.ts
+++ b/admin-app/src/services/api.ts
@@ -6,6 +6,7 @@ import type {
 import axios from "axios";
 import type {
   Referral,
+  ExportReferralsResponse,
   Region,
   Ministry,
   AgencyType,
@@ -74,8 +75,13 @@ class APIService {
     return response.data;
   }
 
-  async fetchReferralsForExport(): Promise<Referral[]> {
-    const response = await this.client.get<Referral[]>("/referrals/export");
+  async fetchReferralsForExport(
+    params: FetchReferralsParams = {},
+  ): Promise<ExportReferralsResponse> {
+    const response = await this.client.get<ExportReferralsResponse>(
+      "/referrals/export",
+      { params },
+    );
     return response.data;
   }
 

--- a/admin-app/src/types/index.ts
+++ b/admin-app/src/types/index.ts
@@ -198,12 +198,32 @@ export interface PaginatedResponse<T> {
   };
 }
 
+export interface ExportReferralsResponse {
+  data: Referral[];
+  meta: {
+    total: number;
+    exported: number;
+    truncated: boolean;
+    maxRows: number;
+  };
+}
+
+export type SortOrder = "asc" | "desc";
+
+export type FilterOperator = "equals" | "contains";
+
 export interface FetchReferralsParams {
   page?: number;
   limit?: number;
   status?: string;
   regionId?: string;
+  assignedToId?: string;
   search?: string;
+  sortBy?: string;
+  sortOrder?: SortOrder;
+  filterBy?: string;
+  filterOperator?: FilterOperator;
+  filterValue?: string;
 }
 
 export const UserRole = {

--- a/backend/src/app.spec.ts
+++ b/backend/src/app.spec.ts
@@ -1,0 +1,113 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { bootstrap, shouldExposeSwagger } from './app';
+
+type JestMock = ReturnType<typeof jest.fn>;
+
+function getNestCreateMock(): JestMock {
+  const nestCore = jest.requireMock<{
+    NestFactory: Record<'create', JestMock>;
+  }>('@nestjs/core');
+  return nestCore.NestFactory['create'];
+}
+
+function getSwaggerMocks(): {
+  createDocument: JestMock;
+  setup: JestMock;
+} {
+  const swagger = jest.requireMock<{
+    SwaggerModule: Record<'createDocument' | 'setup', JestMock>;
+  }>('@nestjs/swagger');
+  return {
+    createDocument: swagger.SwaggerModule['createDocument'],
+    setup: swagger.SwaggerModule['setup'],
+  };
+}
+
+jest.mock('@nestjs/core', () => ({
+  NestFactory: {
+    create: jest.fn(),
+  },
+}));
+
+jest.mock('@nestjs/swagger', () => {
+  const actual =
+    jest.requireActual<typeof import('@nestjs/swagger')>('@nestjs/swagger');
+  const builder = {
+    setTitle: jest.fn().mockReturnThis(),
+    setDescription: jest.fn().mockReturnThis(),
+    setVersion: jest.fn().mockReturnThis(),
+    addBearerAuth: jest.fn().mockReturnThis(),
+    addTag: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({}),
+  };
+
+  return {
+    ...actual,
+    DocumentBuilder: jest.fn(() => builder),
+    SwaggerModule: {
+      createDocument: jest.fn().mockReturnValue({}),
+      setup: jest.fn(),
+    },
+  };
+});
+
+jest.mock('helmet', () => jest.fn(() => jest.fn()));
+
+describe('bootstrap', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const mockApp = {
+    use: jest.fn(),
+    enableCors: jest.fn(),
+    set: jest.fn(),
+    enableShutdownHooks: jest.fn(),
+    setGlobalPrefix: jest.fn(),
+    enableVersioning: jest.fn(),
+    useGlobalPipes: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSwaggerMocks().createDocument.mockReturnValue({});
+    getNestCreateMock().mockResolvedValue(mockApp);
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('should expose Swagger outside production', async () => {
+    process.env.NODE_ENV = 'development';
+
+    await bootstrap();
+
+    const swagger = getSwaggerMocks();
+    expect(shouldExposeSwagger()).toBe(true);
+    expect(swagger.createDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ use: mockApp.use }),
+      expect.any(Object),
+    );
+    expect(swagger.setup).toHaveBeenCalledWith(
+      'api/docs',
+      expect.objectContaining({ use: mockApp.use }),
+      expect.any(Object),
+    );
+  });
+
+  it('should skip Swagger document creation and setup in production', async () => {
+    process.env.NODE_ENV = 'production';
+
+    await bootstrap();
+
+    const swagger = getSwaggerMocks();
+    expect(shouldExposeSwagger()).toBe(false);
+    expect(swagger.createDocument).not.toHaveBeenCalled();
+    expect(swagger.setup).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,30 +6,11 @@ import type { NestExpressApplication } from '@nestjs/platform-express';
 import helmet from 'helmet';
 import { VersioningType, ValidationPipe } from '@nestjs/common';
 
-/**
- *
- */
-export async function bootstrap() {
-  const app: NestExpressApplication =
-    await NestFactory.create<NestExpressApplication>(AppModule, {
-      logger: customLogger,
-    });
-  app.use(helmet());
-  app.enableCors();
-  app.set('trust proxy', 1);
-  app.enableShutdownHooks();
-  app.setGlobalPrefix('api');
-  app.enableVersioning({
-    type: VersioningType.URI,
-    prefix: 'v',
-  });
-  app.useGlobalPipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  );
+export function shouldExposeSwagger(nodeEnv = process.env.NODE_ENV): boolean {
+  return nodeEnv !== 'production';
+}
+
+function setupSwagger(app: NestExpressApplication): void {
   const config = new DocumentBuilder()
     .setTitle('CISB Referral API')
     .setDescription(
@@ -57,10 +38,37 @@ export async function bootstrap() {
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document);
+}
+
+/**
+ *
+ */
+export async function bootstrap() {
+  const app: NestExpressApplication =
+    await NestFactory.create<NestExpressApplication>(AppModule, {
+      logger: customLogger,
+    });
+  app.use(helmet());
+  app.enableCors();
+  app.set('trust proxy', 1);
+  app.enableShutdownHooks();
+  app.setGlobalPrefix('api');
+  app.enableVersioning({
+    type: VersioningType.URI,
+    prefix: 'v',
+  });
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
 
   // Only expose Swagger UI in non-production environments
-  if (process.env.NODE_ENV !== 'production') {
-    SwaggerModule.setup('api/docs', app, document);
+  if (shouldExposeSwagger()) {
+    setupSwagger(app);
   }
 
   return app;

--- a/backend/src/referrals/dto/find-all-referrals.dto.spec.ts
+++ b/backend/src/referrals/dto/find-all-referrals.dto.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@jest/globals';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { FindAllReferralsDto } from './find-all-referrals.dto';
+
+describe('FindAllReferralsDto', () => {
+  it('should trim search and filter values before validation', async () => {
+    const dto = plainToInstance(FindAllReferralsDto, {
+      search: '  Jane  ',
+      filterValue: '  Smith  ',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto.search).toBe('Jane');
+    expect(dto.filterValue).toBe('Smith');
+  });
+
+  it('should reject whitespace-only search and filter values', async () => {
+    const dto = plainToInstance(FindAllReferralsDto, {
+      search: '   ',
+      filterValue: '   ',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.map((error) => error.property)).toEqual(
+      expect.arrayContaining(['search', 'filterValue']),
+    );
+  });
+});

--- a/backend/src/referrals/dto/find-all-referrals.dto.ts
+++ b/backend/src/referrals/dto/find-all-referrals.dto.ts
@@ -1,6 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
+  IsIn,
   IsEnum,
   IsInt,
   IsOptional,
@@ -12,6 +13,77 @@ import {
   MinLength,
 } from 'class-validator';
 import { ReferralStatus } from './update-referral.dto';
+
+export const REFERRAL_COLUMN_KEYS = [
+  'flag',
+  'createdAt',
+  'updatedAt',
+  'referralStatus',
+  'referralOutcome',
+  'referredBy',
+  'ministry',
+  'ministryNameOther',
+  'agencyType',
+  'agencyTypeOther',
+  'partnerAgencyName',
+  'programArea',
+  'referrerContactName',
+  'referrerEmail',
+  'referrerPhone',
+  'individualFirstName',
+  'individualMiddleName',
+  'individualLastName',
+  'individualPreferredName',
+  'individualDateOfBirth',
+  'individualPhone',
+  'personId',
+  'secondaryContact',
+  'bestWayToReach',
+  'region',
+  'specificCityTown',
+  'experiencingHomelessness',
+  'losingHouse',
+  'pendingOrRecentlyReleased',
+  'releaseDate',
+  'currentlyConnectedSupports',
+  'currentlyConnectedSupportsOther',
+  'neededSupports',
+  'neededSupportsOther',
+  'referralReason',
+  'communityPartnerName',
+  'assignedTo',
+  'assignedOn',
+  'firstContactMadeOn',
+  'lottTriage',
+  'lottContact',
+  'followUpDate',
+  'dueDate',
+  'completedDate',
+] as const;
+
+export type ReferralColumnKey = (typeof REFERRAL_COLUMN_KEYS)[number];
+
+export const UNSORTABLE_REFERRAL_COLUMN_KEYS = [
+  'currentlyConnectedSupports',
+  'neededSupports',
+] as const;
+
+export const SORTABLE_REFERRAL_COLUMN_KEYS = REFERRAL_COLUMN_KEYS.filter(
+  (key) =>
+    !UNSORTABLE_REFERRAL_COLUMN_KEYS.includes(
+      key as (typeof UNSORTABLE_REFERRAL_COLUMN_KEYS)[number],
+    ),
+);
+
+export enum ReferralSortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+export enum ReferralFilterOperator {
+  EQUALS = 'equals',
+  CONTAINS = 'contains',
+}
 
 export class FindAllReferralsDto {
   @ApiPropertyOptional({ minimum: 1, default: 1 })
@@ -45,11 +117,52 @@ export class FindAllReferralsDto {
   assignedToId?: string;
 
   @ApiPropertyOptional({
-    description: 'Filter by referrer contact name (starts with)',
+    description: 'Filter by keyword (contains) across referral columns',
   })
   @IsOptional()
   @IsString()
   @MinLength(1)
   @MaxLength(100)
   search?: string;
+
+  @ApiPropertyOptional({
+    enum: SORTABLE_REFERRAL_COLUMN_KEYS,
+    description: 'Sort by referral column key',
+  })
+  @IsOptional()
+  @IsIn(SORTABLE_REFERRAL_COLUMN_KEYS)
+  sortBy?: ReferralColumnKey;
+
+  @ApiPropertyOptional({
+    enum: ReferralSortOrder,
+    description: 'Sort order',
+  })
+  @IsOptional()
+  @IsEnum(ReferralSortOrder)
+  sortOrder?: ReferralSortOrder;
+
+  @ApiPropertyOptional({
+    enum: REFERRAL_COLUMN_KEYS,
+    description: 'Column key to filter by',
+  })
+  @IsOptional()
+  @IsIn(REFERRAL_COLUMN_KEYS)
+  filterBy?: ReferralColumnKey;
+
+  @ApiPropertyOptional({
+    enum: ReferralFilterOperator,
+    description: 'Filter operator for selected column',
+  })
+  @IsOptional()
+  @IsEnum(ReferralFilterOperator)
+  filterOperator?: ReferralFilterOperator;
+
+  @ApiPropertyOptional({
+    description: 'Filter value (free text)',
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  filterValue?: string;
 }

--- a/backend/src/referrals/dto/find-all-referrals.dto.ts
+++ b/backend/src/referrals/dto/find-all-referrals.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
   IsIn,
   IsEnum,
@@ -85,6 +85,10 @@ export enum ReferralFilterOperator {
   CONTAINS = 'contains',
 }
 
+function trimQueryString({ value }: { value: unknown }): unknown {
+  return typeof value === 'string' ? value.trim() : value;
+}
+
 export class FindAllReferralsDto {
   @ApiPropertyOptional({ minimum: 1, default: 1 })
   @IsOptional()
@@ -120,6 +124,7 @@ export class FindAllReferralsDto {
     description: 'Filter by keyword (contains) across referral columns',
   })
   @IsOptional()
+  @Transform(trimQueryString)
   @IsString()
   @MinLength(1)
   @MaxLength(100)
@@ -162,6 +167,7 @@ export class FindAllReferralsDto {
     description: 'Filter value (free text)',
   })
   @IsOptional()
+  @Transform(trimQueryString)
   @IsString()
   @MinLength(1)
   @MaxLength(100)

--- a/backend/src/referrals/dto/find-all-referrals.dto.ts
+++ b/backend/src/referrals/dto/find-all-referrals.dto.ts
@@ -151,7 +151,8 @@ export class FindAllReferralsDto {
 
   @ApiPropertyOptional({
     enum: ReferralFilterOperator,
-    description: 'Filter operator for selected column',
+    description:
+      'Filter operator (contains/equals for text-like columns; equals only for flag, date, and numeric columns)',
   })
   @IsOptional()
   @IsEnum(ReferralFilterOperator)

--- a/backend/src/referrals/referrals-query.builder.spec.ts
+++ b/backend/src/referrals/referrals-query.builder.spec.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from '@jest/globals';
+import { BadRequestException } from '@nestjs/common';
+import { ReleaseFromType, SupportType } from './dto/create-referral.dto';
+import { ReferralOutcome, ReferralStatus } from './dto/update-referral.dto';
+import {
+  ReferralFilterOperator,
+  ReferralSortOrder,
+} from './dto/find-all-referrals.dto';
+import {
+  buildOrderBy,
+  buildWhere,
+  parseBooleanToken,
+  parseDateRange,
+  parseNumberToken,
+} from './referrals-query.builder';
+
+describe('referrals query builder', () => {
+  describe('value parsers', () => {
+    it('should parse supported boolean tokens', () => {
+      expect(parseBooleanToken('yes')).toBe(true);
+      expect(parseBooleanToken('TRUE')).toBe(true);
+      expect(parseBooleanToken('0')).toBe(false);
+      expect(parseBooleanToken('n')).toBe(false);
+      expect(parseBooleanToken('maybe')).toBeUndefined();
+    });
+
+    it('should parse dates as a UTC day range', () => {
+      expect(parseDateRange('2026-01-15')).toEqual({
+        gte: new Date(Date.UTC(2026, 0, 15)),
+        lt: new Date(Date.UTC(2026, 0, 16)),
+      });
+      expect(parseDateRange('not-a-date')).toBeUndefined();
+    });
+
+    it('should parse only finite numbers', () => {
+      expect(parseNumberToken('3.5')).toBe(3.5);
+      expect(parseNumberToken('Infinity')).toBeUndefined();
+      expect(parseNumberToken('not-a-number')).toBeUndefined();
+    });
+  });
+
+  describe('buildWhere', () => {
+    it('should return base filters without search clauses', () => {
+      expect(
+        buildWhere({
+          status: ReferralStatus.OPEN,
+          regionId: 'region-1',
+          assignedToId: 'user-1',
+        }),
+      ).toEqual({
+        referralStatus: ReferralStatus.OPEN,
+        regionId: 'region-1',
+        assignedToId: 'user-1',
+      });
+    });
+
+    it('should ignore blank search and filter values', () => {
+      expect(
+        buildWhere({
+          search: '   ',
+          filterBy: 'individualLastName',
+          filterValue: '   ',
+        }),
+      ).toEqual({});
+    });
+
+    it('should build global search clauses for text, relations, labels, and typed values', () => {
+      const where = buildWhere({ search: 'Contact-Made' });
+
+      expect(where).toEqual({
+        AND: [
+          {
+            OR: expect.arrayContaining([
+              {
+                individualFirstName: {
+                  contains: 'Contact-Made',
+                  mode: 'insensitive',
+                },
+              },
+              {
+                region: {
+                  name: {
+                    contains: 'Contact-Made',
+                    mode: 'insensitive',
+                  },
+                },
+              },
+              { referralStatus: ReferralStatus.CONTACT_MADE },
+            ]),
+          },
+        ],
+      });
+    });
+
+    it('should add support, boolean, numeric, and date matches to global search', () => {
+      const supportWhere = buildWhere({ search: 'Income Assistance Federal' });
+      expect(supportWhere).toEqual({
+        AND: [
+          {
+            OR: expect.arrayContaining([
+              {
+                neededSupports: {
+                  hasSome: [SupportType.INCOME_ASSISTANCE_FEDERAL],
+                },
+              },
+            ]),
+          },
+        ],
+      });
+
+      expect(buildWhere({ search: 'yes' })).toEqual({
+        AND: [
+          {
+            OR: expect.arrayContaining([{ flag: true }]),
+          },
+        ],
+      });
+      expect(buildWhere({ search: '7' })).toEqual({
+        AND: [
+          {
+            OR: expect.arrayContaining([{ lottTriage: 7 }, { lottContact: 7 }]),
+          },
+        ],
+      });
+      expect(buildWhere({ search: '2026-01-15' })).toEqual({
+        AND: [
+          {
+            OR: expect.arrayContaining([
+              {
+                createdAt: {
+                  gte: new Date(Date.UTC(2026, 0, 15)),
+                  lt: new Date(Date.UTC(2026, 0, 16)),
+                },
+              },
+            ]),
+          },
+        ],
+      });
+    });
+
+    it('should build string and relation column filters', () => {
+      expect(
+        buildWhere({
+          filterBy: 'individualLastName',
+          filterOperator: ReferralFilterOperator.EQUALS,
+          filterValue: 'Smith',
+        }),
+      ).toEqual({
+        AND: [
+          {
+            individualLastName: {
+              equals: 'Smith',
+              mode: 'insensitive',
+            },
+          },
+        ],
+      });
+
+      expect(
+        buildWhere({
+          filterBy: 'region',
+          filterValue: 'Island',
+        }),
+      ).toEqual({
+        AND: [
+          {
+            region: {
+              name: {
+                contains: 'Island',
+                mode: 'insensitive',
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it('should build enum, support, date, numeric, and boolean column filters', () => {
+      expect(
+        buildWhere({
+          filterBy: 'referralOutcome',
+          filterOperator: ReferralFilterOperator.EQUALS,
+          filterValue: 'Nonfinancial Supports Provided',
+        }),
+      ).toEqual({
+        AND: [{ referralOutcome: ReferralOutcome.SERVICES_PROVIDED }],
+      });
+
+      expect(
+        buildWhere({
+          filterBy: 'pendingOrRecentlyReleased',
+          filterOperator: ReferralFilterOperator.EQUALS,
+          filterValue: 'Hospital/Medical Facility',
+        }),
+      ).toEqual({
+        AND: [
+          {
+            pendingOrRecentlyReleased:
+              ReleaseFromType.HOSPITAL_MEDICAL_FACILITY,
+          },
+        ],
+      });
+
+      expect(
+        buildWhere({
+          filterBy: 'neededSupports',
+          filterOperator: ReferralFilterOperator.EQUALS,
+          filterValue: 'Income Assistance (Provincial)',
+        }),
+      ).toEqual({
+        AND: [
+          {
+            neededSupports: {
+              has: SupportType.INCOME_ASSISTANCE_PROVINCIAL,
+            },
+          },
+        ],
+      });
+
+      expect(
+        buildWhere({
+          filterBy: 'neededSupports',
+          filterValue: 'Income Assistance',
+        }),
+      ).toEqual({
+        AND: [
+          {
+            neededSupports: {
+              hasSome: [
+                SupportType.INCOME_ASSISTANCE_PROVINCIAL,
+                SupportType.INCOME_ASSISTANCE_FEDERAL,
+              ],
+            },
+          },
+        ],
+      });
+
+      expect(
+        buildWhere({
+          filterBy: 'createdAt',
+          filterValue: '2026-01-15',
+        }),
+      ).toEqual({
+        AND: [
+          {
+            createdAt: {
+              gte: new Date(Date.UTC(2026, 0, 15)),
+              lt: new Date(Date.UTC(2026, 0, 16)),
+            },
+          },
+        ],
+      });
+
+      expect(
+        buildWhere({
+          filterBy: 'lottTriage',
+          filterValue: '12.5',
+        }),
+      ).toEqual({ AND: [{ lottTriage: 12.5 }] });
+
+      expect(buildWhere({ filterBy: 'flag', filterValue: 'true' })).toEqual({
+        AND: [{ flag: true }],
+      });
+    });
+
+    it('should reject invalid typed and label-backed filters', () => {
+      expect(() =>
+        buildWhere({
+          filterBy: 'referralStatus',
+          filterOperator: ReferralFilterOperator.EQUALS,
+          filterValue: 'Not a status',
+        }),
+      ).toThrow(BadRequestException);
+
+      expect(() =>
+        buildWhere({
+          filterBy: 'createdAt',
+          filterValue: 'not-a-date',
+        }),
+      ).toThrow(BadRequestException);
+
+      expect(() =>
+        buildWhere({
+          filterBy: 'lottContact',
+          filterValue: 'not-a-number',
+        }),
+      ).toThrow(BadRequestException);
+
+      expect(() =>
+        buildWhere({
+          filterBy: 'flag',
+          filterValue: 'maybe',
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should reject contains operator for typed columns', () => {
+      expect(() =>
+        buildWhere({
+          filterBy: 'createdAt',
+          filterOperator: ReferralFilterOperator.CONTAINS,
+          filterValue: '2026-01-15',
+        }),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  describe('buildOrderBy', () => {
+    it('should build default, scalar, and relation sort clauses', () => {
+      expect(buildOrderBy()).toEqual({ createdAt: 'desc' });
+      expect(buildOrderBy('individualLastName', ReferralSortOrder.ASC)).toEqual(
+        {
+          individualLastName: 'asc',
+        },
+      );
+      expect(buildOrderBy('assignedTo', ReferralSortOrder.DESC)).toEqual({
+        assignedTo: { fullName: 'desc' },
+      });
+    });
+
+    it('should reject unsupported array sort columns', () => {
+      expect(() =>
+        buildOrderBy('currentlyConnectedSupports', ReferralSortOrder.ASC),
+      ).toThrow(BadRequestException);
+    });
+  });
+});

--- a/backend/src/referrals/referrals-query.builder.ts
+++ b/backend/src/referrals/referrals-query.builder.ts
@@ -138,6 +138,13 @@ const SUPPORT_LABELS: Record<string, string> = {
   OTHERS: 'Others',
 };
 
+const EQUALS_ONLY_FILTER_COLUMN_KEYS = new Set<ReferralColumnKey>([
+  'flag',
+  ...DATE_COLUMN_KEYS,
+  'lottTriage',
+  'lottContact',
+]);
+
 // ---------------------------------------------------------------------------
 // Prisma filter helpers
 // ---------------------------------------------------------------------------
@@ -236,6 +243,24 @@ function requireColumnFilter(
   }
 
   throw new BadRequestException(`Invalid filter value for ${filterBy}`);
+}
+
+function resolveFilterOperator(
+  filterBy: ReferralColumnKey,
+  filterOperator?: ReferralFilterOperator,
+): ReferralFilterOperator {
+  if (!EQUALS_ONLY_FILTER_COLUMN_KEYS.has(filterBy)) {
+    return filterOperator ?? ReferralFilterOperator.CONTAINS;
+  }
+
+  if (
+    filterOperator === undefined ||
+    filterOperator === ReferralFilterOperator.EQUALS
+  ) {
+    return ReferralFilterOperator.EQUALS;
+  }
+
+  throw new BadRequestException(`Invalid filter operator for ${filterBy}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -342,7 +367,7 @@ function buildColumnFilter(
   }
 
   const value = filterValue.trim();
-  const operator = filterOperator ?? ReferralFilterOperator.CONTAINS;
+  const operator = resolveFilterOperator(filterBy, filterOperator);
 
   switch (filterBy) {
     case 'flag': {

--- a/backend/src/referrals/referrals-query.builder.ts
+++ b/backend/src/referrals/referrals-query.builder.ts
@@ -1,0 +1,515 @@
+import {
+  ReferredByType,
+  SupportType,
+  YesNoUnknown,
+  ReleaseFromType,
+} from './dto/create-referral.dto';
+import { BadRequestException } from '@nestjs/common';
+import { ReferralStatus, ReferralOutcome } from './dto/update-referral.dto';
+import {
+  FindAllReferralsDto,
+  ReferralColumnKey,
+  ReferralFilterOperator,
+  ReferralSortOrder,
+} from './dto/find-all-referrals.dto';
+import { Prisma } from '../generated/prisma/client';
+
+export const REFERRAL_INCLUDE = {
+  region: true,
+  ministry: true,
+  agencyType: true,
+  assignedTo: true,
+} satisfies Prisma.ReferralInclude;
+
+const GLOBAL_SEARCH_STRING_FIELDS = [
+  'ministryNameOther',
+  'agencyTypeOther',
+  'partnerAgencyName',
+  'programArea',
+  'referrerContactName',
+  'referrerEmail',
+  'referrerPhone',
+  'individualFirstName',
+  'individualMiddleName',
+  'individualLastName',
+  'individualPreferredName',
+  'individualPhone',
+  'personId',
+  'secondaryContact',
+  'bestWayToReach',
+  'specificCityTown',
+  'currentlyConnectedSupportsOther',
+  'neededSupportsOther',
+  'referralReason',
+  'communityPartnerName',
+] as const;
+
+const DATE_COLUMN_KEYS = [
+  'createdAt',
+  'updatedAt',
+  'individualDateOfBirth',
+  'releaseDate',
+  'assignedOn',
+  'firstContactMadeOn',
+  'followUpDate',
+  'dueDate',
+  'completedDate',
+] as const;
+
+const ENUM_COLUMN_KEYS = [
+  'referralStatus',
+  'referralOutcome',
+  'referredBy',
+  'experiencingHomelessness',
+  'losingHouse',
+  'pendingOrRecentlyReleased',
+] as const;
+
+const SEARCHABLE_ENUM_VALUES = {
+  referralStatus: Object.values(ReferralStatus),
+  referralOutcome: Object.values(ReferralOutcome),
+  referredBy: Object.values(ReferredByType),
+  experiencingHomelessness: Object.values(YesNoUnknown),
+  losingHouse: Object.values(YesNoUnknown),
+  pendingOrRecentlyReleased: Object.values(ReleaseFromType),
+};
+
+const SEARCHABLE_ENUM_LABELS: Record<string, Record<string, string>> = {
+  referralStatus: {
+    OPEN: 'Open',
+    ASSIGNED: 'Assigned',
+    CONTACT_MADE: 'Contact-Made',
+    CLOSED: 'Closed',
+  },
+  referralOutcome: {
+    BCEA_APPLICATION_SUBMITTED: 'BCEA Application Submitted',
+    BCEA_APPLICATION_COMPLETED_FILE_OPENED:
+      'BCEA Application Completed - File Opened',
+    SUPPLEMENTS_ISSUED: 'Supplements Issued',
+    CASE_MANAGED: 'Case Managed',
+    SERVICES_PROVIDED: 'Nonfinancial Supports Provided',
+    NOT_LOCATED: 'Not Located',
+    LOCATED_REFUSED_SERVICE: 'Located - Refused Service',
+    NON_APPROPRIATE_REFERRAL_RETURNED: 'Non-Appropriate Referral - Returned',
+    REFERRED_TO_VS_CS: 'Referred to VS/CS',
+    REFERRED_TO_COMMUNITY_PARTNER: 'Referred to Community Partner',
+  },
+  referredBy: {
+    PARTNER_MINISTRY: 'Partner Ministry',
+    SDPR_INTERNAL: 'SDPR Internal',
+    PARTNER_AGENCY: 'Partner Agency',
+  },
+  experiencingHomelessness: {
+    YES: 'Yes',
+    NO: 'No',
+    UNKNOWN: 'Unknown',
+  },
+  losingHouse: {
+    YES: 'Yes',
+    NO: 'No',
+    UNKNOWN: 'Unknown',
+  },
+  pendingOrRecentlyReleased: {
+    NO: 'No',
+    HOSPITAL_MEDICAL_FACILITY: 'Hospital/Medical Facility',
+    CORRECTIONS: 'Corrections',
+    YOUTH_TRANSITION_MCFD: 'Youth Transition (MCFD)',
+    YOUTH_TRANSITION_DELEGATED_ABORIGINAL_AGENCY:
+      'Youth Transition (Delegated Aboriginal Agency)',
+    ALCOHOL_DRUG_FACILITY: 'Alcohol/Drug Facility',
+  },
+};
+
+const SUPPORT_VALUES = Object.values(SupportType);
+
+const SUPPORT_LABELS: Record<string, string> = {
+  CULTURAL: 'Cultural',
+  COMMUNITY_SUPPORTS: 'Community Supports',
+  FOOD_SECURITY: 'Food Security',
+  HOUSING: 'Housing',
+  INCOME_ASSISTANCE_PROVINCIAL: 'Income Assistance (Provincial)',
+  INCOME_ASSISTANCE_FEDERAL: 'Income Assistance (Federal)',
+  MENTAL_HEALTH: 'Mental Health',
+  SYSTEM_NAVIGATION: 'System Navigation',
+  HEALTH_SERVICES: 'Health Services',
+  SUBSTANCE_USE: 'Substance Use',
+  INDIGENOUS_SUPPORTS: 'Indigenous Supports',
+  INTEGRATED_JUSTICE_SUPPORTS: 'Integrated Justice Supports',
+  OTHERS: 'Others',
+};
+
+// ---------------------------------------------------------------------------
+// Prisma filter helpers
+// ---------------------------------------------------------------------------
+
+function containsInsensitive(value: string) {
+  return { contains: value, mode: 'insensitive' as const };
+}
+
+function equalsInsensitive(value: string) {
+  return { equals: value, mode: 'insensitive' as const };
+}
+
+// ---------------------------------------------------------------------------
+// Value-parsing utilities
+// ---------------------------------------------------------------------------
+
+function toNormalized(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function toComparable(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, ' ')
+    .replaceAll(/\s+/g, ' ')
+    .trim();
+}
+
+export function parseBooleanToken(value: string): boolean | undefined {
+  const normalized = toNormalized(value);
+  if (['yes', 'y', 'true', '1'].includes(normalized)) {
+    return true;
+  }
+  if (['no', 'n', 'false', '0'].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+export function parseDateRange(
+  value: string,
+): { gte: Date; lt: Date } | undefined {
+  const parsed = new Date(value.trim());
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+
+  const start = new Date(
+    Date.UTC(
+      parsed.getUTCFullYear(),
+      parsed.getUTCMonth(),
+      parsed.getUTCDate(),
+    ),
+  );
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+
+  return { gte: start, lt: end };
+}
+
+export function parseNumberToken(value: string): number | undefined {
+  const parsed = Number(value.trim());
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function findEnumMatches(
+  values: readonly string[],
+  input: string,
+  operator: ReferralFilterOperator,
+  labels: Record<string, string> = {},
+): string[] {
+  const normalized = toComparable(input);
+  if (!normalized) {
+    return [];
+  }
+
+  return values.filter((value) => {
+    const candidates = [value, value.replaceAll('_', ' '), labels[value]]
+      .filter((candidate): candidate is string => Boolean(candidate))
+      .map(toComparable)
+      .filter(Boolean);
+
+    return operator === ReferralFilterOperator.EQUALS
+      ? candidates.includes(normalized)
+      : candidates.some((candidate) => candidate.includes(normalized));
+  });
+}
+
+function requireColumnFilter(
+  filter: Prisma.ReferralWhereInput | undefined,
+  filterBy: ReferralColumnKey,
+): Prisma.ReferralWhereInput {
+  if (filter) {
+    return filter;
+  }
+
+  throw new BadRequestException(`Invalid filter value for ${filterBy}`);
+}
+
+// ---------------------------------------------------------------------------
+// Per-type filter builders
+// ---------------------------------------------------------------------------
+
+function buildStringFilter(
+  value: string,
+  operator: ReferralFilterOperator,
+):
+  | { contains: string; mode: 'insensitive' }
+  | { equals: string; mode: 'insensitive' } {
+  return operator === ReferralFilterOperator.EQUALS
+    ? equalsInsensitive(value)
+    : containsInsensitive(value);
+}
+
+function buildEnumFilter(
+  field: (typeof ENUM_COLUMN_KEYS)[number],
+  value: string,
+  operator: ReferralFilterOperator,
+): Prisma.ReferralWhereInput | undefined {
+  const matches = findEnumMatches(
+    SEARCHABLE_ENUM_VALUES[field],
+    value,
+    operator,
+    SEARCHABLE_ENUM_LABELS[field],
+  );
+  if (matches.length === 0) {
+    return undefined;
+  }
+  return matches.length === 1
+    ? { [field]: matches[0] }
+    : { [field]: { in: matches } };
+}
+
+function buildDateFilter(
+  field: (typeof DATE_COLUMN_KEYS)[number],
+  value: string,
+): Prisma.ReferralWhereInput | undefined {
+  const range = parseDateRange(value);
+  return range ? { [field]: range } : undefined;
+}
+
+function buildNumericFilter(
+  field: 'lottTriage' | 'lottContact',
+  value: string,
+): Prisma.ReferralWhereInput | undefined {
+  const parsed = parseNumberToken(value);
+  return parsed === undefined ? undefined : { [field]: parsed };
+}
+
+function buildRelationFilter(
+  field: 'region' | 'ministry' | 'agencyType' | 'assignedTo',
+  value: string,
+  operator: ReferralFilterOperator,
+): Prisma.ReferralWhereInput {
+  const filter = buildStringFilter(value, operator);
+  switch (field) {
+    case 'region':
+      return { region: { name: filter } };
+    case 'ministry':
+      return { ministry: { name: filter } };
+    case 'agencyType':
+      return { agencyType: { name: filter } };
+    case 'assignedTo':
+      return { assignedTo: { fullName: filter } };
+  }
+}
+
+function buildSupportArrayFilter(
+  field: 'currentlyConnectedSupports' | 'neededSupports',
+  value: string,
+  operator: ReferralFilterOperator,
+): Prisma.ReferralWhereInput | undefined {
+  const matches = findEnumMatches(
+    SUPPORT_VALUES,
+    value,
+    operator,
+    SUPPORT_LABELS,
+  );
+  if (matches.length === 0) {
+    return undefined;
+  }
+
+  if (operator === ReferralFilterOperator.EQUALS && matches.length === 1) {
+    return { [field]: { has: matches[0] as SupportType } };
+  }
+
+  return { [field]: { hasSome: matches as SupportType[] } };
+}
+
+// ---------------------------------------------------------------------------
+// Composite query builders (exported for use in the service)
+// ---------------------------------------------------------------------------
+
+function buildColumnFilter(
+  filterBy?: ReferralColumnKey,
+  filterOperator?: ReferralFilterOperator,
+  filterValue?: string,
+): Prisma.ReferralWhereInput | undefined {
+  if (!filterBy || !filterValue?.trim()) {
+    return undefined;
+  }
+
+  const value = filterValue.trim();
+  const operator = filterOperator ?? ReferralFilterOperator.CONTAINS;
+
+  switch (filterBy) {
+    case 'flag': {
+      const parsed = parseBooleanToken(value);
+      if (parsed === undefined) {
+        throw new BadRequestException(`Invalid filter value for ${filterBy}`);
+      }
+      return { flag: parsed };
+    }
+    case 'region':
+    case 'ministry':
+    case 'agencyType':
+    case 'assignedTo':
+      return buildRelationFilter(filterBy, value, operator);
+    case 'referralStatus':
+    case 'referralOutcome':
+    case 'referredBy':
+    case 'experiencingHomelessness':
+    case 'losingHouse':
+    case 'pendingOrRecentlyReleased':
+      return requireColumnFilter(
+        buildEnumFilter(filterBy, value, operator),
+        filterBy,
+      );
+    case 'createdAt':
+    case 'updatedAt':
+    case 'individualDateOfBirth':
+    case 'releaseDate':
+    case 'assignedOn':
+    case 'firstContactMadeOn':
+    case 'followUpDate':
+    case 'dueDate':
+    case 'completedDate':
+      return requireColumnFilter(buildDateFilter(filterBy, value), filterBy);
+    case 'lottTriage':
+    case 'lottContact':
+      return requireColumnFilter(buildNumericFilter(filterBy, value), filterBy);
+    case 'currentlyConnectedSupports':
+    case 'neededSupports':
+      return requireColumnFilter(
+        buildSupportArrayFilter(filterBy, value, operator),
+        filterBy,
+      );
+    default:
+      return { [filterBy]: buildStringFilter(value, operator) };
+  }
+}
+
+function buildGlobalSearch(
+  search?: string,
+): Prisma.ReferralWhereInput | undefined {
+  const value = search?.trim();
+  if (!value) {
+    return undefined;
+  }
+
+  const orFilters: Prisma.ReferralWhereInput[] =
+    GLOBAL_SEARCH_STRING_FIELDS.map((field) => ({
+      [field]: containsInsensitive(value),
+    }));
+
+  orFilters.push(
+    { region: { name: containsInsensitive(value) } },
+    { ministry: { name: containsInsensitive(value) } },
+    { agencyType: { name: containsInsensitive(value) } },
+    { assignedTo: { fullName: containsInsensitive(value) } },
+  );
+
+  for (const enumField of ENUM_COLUMN_KEYS) {
+    const filter = buildEnumFilter(
+      enumField,
+      value,
+      ReferralFilterOperator.CONTAINS,
+    );
+    if (filter) {
+      orFilters.push(filter);
+    }
+  }
+
+  const supportMatches = findEnumMatches(
+    SUPPORT_VALUES,
+    value,
+    ReferralFilterOperator.CONTAINS,
+    SUPPORT_LABELS,
+  );
+  if (supportMatches.length > 0) {
+    orFilters.push(
+      {
+        currentlyConnectedSupports: {
+          hasSome: supportMatches as SupportType[],
+        },
+      },
+      { neededSupports: { hasSome: supportMatches as SupportType[] } },
+    );
+  }
+
+  const parsedBoolean = parseBooleanToken(value);
+  if (parsedBoolean !== undefined) {
+    orFilters.push({ flag: parsedBoolean });
+  }
+
+  const parsedNumber = parseNumberToken(value);
+  if (parsedNumber !== undefined) {
+    orFilters.push({ lottTriage: parsedNumber }, { lottContact: parsedNumber });
+  }
+
+  for (const dateField of DATE_COLUMN_KEYS) {
+    const filter = buildDateFilter(dateField, value);
+    if (filter) {
+      orFilters.push(filter);
+    }
+  }
+
+  return { OR: orFilters };
+}
+
+export function buildWhere(
+  params: FindAllReferralsDto,
+): Prisma.ReferralWhereInput {
+  const andClauses: Prisma.ReferralWhereInput[] = [];
+
+  const globalSearch = buildGlobalSearch(params.search);
+  if (globalSearch) {
+    andClauses.push(globalSearch);
+  }
+
+  const columnFilter = buildColumnFilter(
+    params.filterBy,
+    params.filterOperator,
+    params.filterValue,
+  );
+  if (columnFilter) {
+    andClauses.push(columnFilter);
+  }
+
+  return {
+    ...(params.status && { referralStatus: params.status }),
+    ...(params.regionId && { regionId: params.regionId }),
+    ...(params.assignedToId && { assignedToId: params.assignedToId }),
+    ...(andClauses.length > 0 && { AND: andClauses }),
+  };
+}
+
+export function buildOrderBy(
+  sortBy?: ReferralColumnKey,
+  sortOrder?: ReferralSortOrder,
+): Prisma.ReferralOrderByWithRelationInput {
+  if (!sortBy) {
+    return { createdAt: 'desc' };
+  }
+
+  const order: Prisma.SortOrder =
+    sortOrder === ReferralSortOrder.ASC ? 'asc' : 'desc';
+
+  switch (sortBy) {
+    case 'region':
+      return { region: { name: order } };
+    case 'ministry':
+      return { ministry: { name: order } };
+    case 'agencyType':
+      return { agencyType: { name: order } };
+    case 'assignedTo':
+      return { assignedTo: { fullName: order } };
+    case 'currentlyConnectedSupports':
+    case 'neededSupports':
+      throw new BadRequestException(`${sortBy} cannot be sorted`);
+    default:
+      return { [sortBy]: order };
+  }
+}

--- a/backend/src/referrals/referrals.controller.spec.ts
+++ b/backend/src/referrals/referrals.controller.spec.ts
@@ -6,6 +6,7 @@ import { ReferralStatus } from './dto/update-referral.dto';
 const mockReferralsService = {
   create: jest.fn(),
   findAll: jest.fn(),
+  findAllForExport: jest.fn(),
   findOne: jest.fn(),
   update: jest.fn(),
 };
@@ -105,6 +106,37 @@ describe('ReferralsController', () => {
 
       expect(result).toEqual(mockReferral);
       expect(mockReferralsService.findOne).toHaveBeenCalledWith('referral-1');
+    });
+  });
+
+  describe('exportAll', () => {
+    it('should delegate to service with user id and query params', async () => {
+      const exportResult = {
+        data: [mockReferral],
+        meta: {
+          total: 1,
+          exported: 1,
+          truncated: false,
+          maxRows: 10000,
+        },
+      };
+      const query = {
+        search: 'smith',
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+        filterBy: 'referralStatus',
+        filterOperator: 'contains',
+        filterValue: 'open',
+      };
+      mockReferralsService.findAllForExport.mockResolvedValue(exportResult);
+
+      const result = await controller.exportAll(mockUser as any, query as any);
+
+      expect(result).toEqual(exportResult);
+      expect(mockReferralsService.findAllForExport).toHaveBeenCalledWith(
+        'user-1',
+        query,
+      );
     });
   });
 

--- a/backend/src/referrals/referrals.controller.ts
+++ b/backend/src/referrals/referrals.controller.ts
@@ -138,9 +138,46 @@ export class ReferralsController {
   @ApiOperation({
     summary: 'Get all referrals (capped) for client-side CSV export',
   })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description: 'Filter by keyword across referral columns',
+  })
+  @ApiQuery({
+    name: 'sortBy',
+    required: false,
+    enum: SORTABLE_REFERRAL_COLUMN_KEYS,
+    description: 'Sort by referral column key',
+  })
+  @ApiQuery({
+    name: 'sortOrder',
+    required: false,
+    enum: ReferralSortOrder,
+    description: 'Sort order',
+  })
+  @ApiQuery({
+    name: 'filterBy',
+    required: false,
+    enum: REFERRAL_COLUMN_KEYS,
+    description: 'Column key to filter by',
+  })
+  @ApiQuery({
+    name: 'filterOperator',
+    required: false,
+    enum: ReferralFilterOperator,
+    description: 'Filter operator for selected column',
+  })
+  @ApiQuery({
+    name: 'filterValue',
+    required: false,
+    type: String,
+    description: 'Filter value (free text)',
+  })
   @ApiResponse({
     status: 200,
-    description: 'All referrals, unpaginated, with relations included',
+    description:
+      'Capped list of referrals with export metadata (total, exported, truncated, maxRows)',
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async exportAll(

--- a/backend/src/referrals/referrals.controller.ts
+++ b/backend/src/referrals/referrals.controller.ts
@@ -17,8 +17,15 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { ReferralsService } from './referrals.service';
+import type { ReferralExportResult } from './referrals.service';
 import { CreateReferralDto } from './dto/create-referral.dto';
-import { FindAllReferralsDto } from './dto/find-all-referrals.dto';
+import {
+  FindAllReferralsDto,
+  REFERRAL_COLUMN_KEYS,
+  SORTABLE_REFERRAL_COLUMN_KEYS,
+  ReferralFilterOperator,
+  ReferralSortOrder,
+} from './dto/find-all-referrals.dto';
 import { UpdateReferralDto, ReferralStatus } from './dto/update-referral.dto';
 import type { Referral, User } from '../generated/prisma/client';
 import {
@@ -87,7 +94,37 @@ export class ReferralsController {
     name: 'search',
     required: false,
     type: String,
-    description: 'Filter by referrer contact name (starts with)',
+    description: 'Filter by keyword (contains) across referral columns',
+  })
+  @ApiQuery({
+    name: 'sortBy',
+    required: false,
+    enum: SORTABLE_REFERRAL_COLUMN_KEYS,
+    description: 'Sort by referral column key',
+  })
+  @ApiQuery({
+    name: 'sortOrder',
+    required: false,
+    enum: ReferralSortOrder,
+    description: 'Sort order',
+  })
+  @ApiQuery({
+    name: 'filterBy',
+    required: false,
+    enum: REFERRAL_COLUMN_KEYS,
+    description: 'Column key to filter by',
+  })
+  @ApiQuery({
+    name: 'filterOperator',
+    required: false,
+    enum: ReferralFilterOperator,
+    description: 'Filter operator for selected column',
+  })
+  @ApiQuery({
+    name: 'filterValue',
+    required: false,
+    type: String,
+    description: 'Filter value (free text)',
   })
   @ApiResponse({ status: 200, description: 'List of referrals' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -106,8 +143,11 @@ export class ReferralsController {
     description: 'All referrals, unpaginated, with relations included',
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async exportAll(@CurrentUser() user: User): Promise<Referral[]> {
-    return this.referralsService.findAllForExport(user.id);
+  async exportAll(
+    @CurrentUser() user: User,
+    @Query() query: FindAllReferralsDto,
+  ): Promise<ReferralExportResult> {
+    return this.referralsService.findAllForExport(user.id, query);
   }
 
   @Get(':id')

--- a/backend/src/referrals/referrals.controller.ts
+++ b/backend/src/referrals/referrals.controller.ts
@@ -118,7 +118,8 @@ export class ReferralsController {
     name: 'filterOperator',
     required: false,
     enum: ReferralFilterOperator,
-    description: 'Filter operator for selected column',
+    description:
+      'Filter operator (contains/equals for text-like columns; equals only for flag, date, and numeric columns)',
   })
   @ApiQuery({
     name: 'filterValue',
@@ -166,7 +167,8 @@ export class ReferralsController {
     name: 'filterOperator',
     required: false,
     enum: ReferralFilterOperator,
-    description: 'Filter operator for selected column',
+    description:
+      'Filter operator (contains/equals for text-like columns; equals only for flag, date, and numeric columns)',
   })
   @ApiQuery({
     name: 'filterValue',

--- a/backend/src/referrals/referrals.controller.ts
+++ b/backend/src/referrals/referrals.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
   ParseUUIDPipe,
   UseGuards,
+  applyDecorators,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -36,6 +37,92 @@ import {
 import { CurrentUser, CurrentContact } from '../auth/decorators';
 import type { AuthenticatedContact } from '../auth/interfaces';
 
+const FILTER_OPERATOR_DESCRIPTION =
+  'Filter operator (contains/equals for text-like columns; equals only for flag, date, and numeric columns)';
+
+function ApiReferralPaginationQueries(): MethodDecorator {
+  return applyDecorators(
+    ApiQuery({
+      name: 'page',
+      required: false,
+      type: Number,
+      description: 'Page number (default: 1)',
+    }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      description: 'Items per page (default: 10)',
+    }),
+  );
+}
+
+function ApiReferralQueryCriteria(): MethodDecorator {
+  return applyDecorators(
+    ApiQuery({
+      name: 'status',
+      required: false,
+      enum: ReferralStatus,
+      description: 'Filter by status',
+    }),
+    ApiQuery({
+      name: 'regionId',
+      required: false,
+      type: String,
+      description: 'Filter by region',
+    }),
+    ApiQuery({
+      name: 'assignedToId',
+      required: false,
+      type: String,
+      description: 'Filter by assigned user',
+    }),
+    ApiQuery({
+      name: 'search',
+      required: false,
+      type: String,
+      description: 'Filter by keyword across referral columns',
+    }),
+    ApiQuery({
+      name: 'sortBy',
+      required: false,
+      enum: SORTABLE_REFERRAL_COLUMN_KEYS,
+      description: 'Sort by referral column key',
+    }),
+    ApiQuery({
+      name: 'sortOrder',
+      required: false,
+      enum: ReferralSortOrder,
+      description: 'Sort order',
+    }),
+    ApiQuery({
+      name: 'filterBy',
+      required: false,
+      enum: REFERRAL_COLUMN_KEYS,
+      description: 'Column key to filter by',
+    }),
+    ApiQuery({
+      name: 'filterOperator',
+      required: false,
+      enum: ReferralFilterOperator,
+      description: FILTER_OPERATOR_DESCRIPTION,
+    }),
+    ApiQuery({
+      name: 'filterValue',
+      required: false,
+      type: String,
+      description: 'Filter value (free text)',
+    }),
+  );
+}
+
+function ApiReferralListQueries(): MethodDecorator {
+  return applyDecorators(
+    ApiReferralPaginationQueries(),
+    ApiReferralQueryCriteria(),
+  );
+}
+
 @ApiTags('referrals')
 @Controller({ path: 'referrals', version: '1' })
 export class ReferralsController {
@@ -60,73 +147,7 @@ export class ReferralsController {
   @UseGuards(AdminAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get all referrals with pagination and filtering' })
-  @ApiQuery({
-    name: 'page',
-    required: false,
-    type: Number,
-    description: 'Page number (default: 1)',
-  })
-  @ApiQuery({
-    name: 'limit',
-    required: false,
-    type: Number,
-    description: 'Items per page (default: 10)',
-  })
-  @ApiQuery({
-    name: 'status',
-    required: false,
-    enum: ReferralStatus,
-    description: 'Filter by status',
-  })
-  @ApiQuery({
-    name: 'regionId',
-    required: false,
-    type: String,
-    description: 'Filter by region',
-  })
-  @ApiQuery({
-    name: 'assignedToId',
-    required: false,
-    type: String,
-    description: 'Filter by assigned user',
-  })
-  @ApiQuery({
-    name: 'search',
-    required: false,
-    type: String,
-    description: 'Filter by keyword (contains) across referral columns',
-  })
-  @ApiQuery({
-    name: 'sortBy',
-    required: false,
-    enum: SORTABLE_REFERRAL_COLUMN_KEYS,
-    description: 'Sort by referral column key',
-  })
-  @ApiQuery({
-    name: 'sortOrder',
-    required: false,
-    enum: ReferralSortOrder,
-    description: 'Sort order',
-  })
-  @ApiQuery({
-    name: 'filterBy',
-    required: false,
-    enum: REFERRAL_COLUMN_KEYS,
-    description: 'Column key to filter by',
-  })
-  @ApiQuery({
-    name: 'filterOperator',
-    required: false,
-    enum: ReferralFilterOperator,
-    description:
-      'Filter operator (contains/equals for text-like columns; equals only for flag, date, and numeric columns)',
-  })
-  @ApiQuery({
-    name: 'filterValue',
-    required: false,
-    type: String,
-    description: 'Filter value (free text)',
-  })
+  @ApiReferralListQueries()
   @ApiResponse({ status: 200, description: 'List of referrals' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async findAll(@Query() query: FindAllReferralsDto) {
@@ -139,43 +160,7 @@ export class ReferralsController {
   @ApiOperation({
     summary: 'Get all referrals (capped) for client-side CSV export',
   })
-  @ApiQuery({
-    name: 'search',
-    required: false,
-    type: String,
-    description: 'Filter by keyword across referral columns',
-  })
-  @ApiQuery({
-    name: 'sortBy',
-    required: false,
-    enum: SORTABLE_REFERRAL_COLUMN_KEYS,
-    description: 'Sort by referral column key',
-  })
-  @ApiQuery({
-    name: 'sortOrder',
-    required: false,
-    enum: ReferralSortOrder,
-    description: 'Sort order',
-  })
-  @ApiQuery({
-    name: 'filterBy',
-    required: false,
-    enum: REFERRAL_COLUMN_KEYS,
-    description: 'Column key to filter by',
-  })
-  @ApiQuery({
-    name: 'filterOperator',
-    required: false,
-    enum: ReferralFilterOperator,
-    description:
-      'Filter operator (contains/equals for text-like columns; equals only for flag, date, and numeric columns)',
-  })
-  @ApiQuery({
-    name: 'filterValue',
-    required: false,
-    type: String,
-    description: 'Filter value (free text)',
-  })
+  @ApiReferralQueryCriteria()
   @ApiResponse({
     status: 200,
     description:

--- a/backend/src/referrals/referrals.service.spec.ts
+++ b/backend/src/referrals/referrals.service.spec.ts
@@ -652,6 +652,43 @@ describe('ReferralsService', () => {
       );
     });
 
+    it('should default typed filters to equals when operator is omitted', async () => {
+      mockPrismaService.referral.findMany.mockResolvedValue([]);
+      mockPrismaService.referral.count.mockResolvedValue(0);
+
+      await service.findAll({
+        filterBy: 'flag',
+        filterValue: 'yes',
+      });
+
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            AND: [{ flag: true }],
+          },
+        }),
+      );
+    });
+
+    it.each([
+      { filterBy: 'flag', filterValue: 'yes' },
+      { filterBy: 'createdAt', filterValue: '2026-01-15' },
+      { filterBy: 'lottTriage', filterValue: '5' },
+    ])(
+      'should reject contains operator for typed filter column $filterBy',
+      async ({ filterBy, filterValue }) => {
+        await expect(
+          service.findAll({
+            filterBy,
+            filterOperator: 'contains',
+            filterValue,
+          }),
+        ).rejects.toThrow(BadRequestException);
+
+        expect(mockPrismaService.referral.findMany).not.toHaveBeenCalled();
+      },
+    );
+
     it('should reject invalid typed filter values', async () => {
       await expect(
         service.findAll({

--- a/backend/src/referrals/referrals.service.spec.ts
+++ b/backend/src/referrals/referrals.service.spec.ts
@@ -105,6 +105,7 @@ describe('ReferralsService', () => {
 
   const mockAuditService = {
     logReferralChange: jest.fn().mockResolvedValue(undefined),
+    logGlobal: jest.fn().mockResolvedValue(undefined),
   };
 
   const mockMailService = {
@@ -507,7 +508,7 @@ describe('ReferralsService', () => {
       );
     });
 
-    it('should filter by referrerContactName startsWith when search is provided', async () => {
+    it('should use contains search across columns when search is provided', async () => {
       mockPrismaService.referral.findMany.mockResolvedValue([]);
       mockPrismaService.referral.count.mockResolvedValue(0);
 
@@ -516,15 +517,35 @@ describe('ReferralsService', () => {
       expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: {
-            referrerContactName: { startsWith: 'Jane', mode: 'insensitive' },
+            AND: [
+              {
+                OR: expect.arrayContaining([
+                  {
+                    referrerContactName: {
+                      contains: 'Jane',
+                      mode: 'insensitive',
+                    },
+                  },
+                  {
+                    individualFirstName: {
+                      contains: 'Jane',
+                      mode: 'insensitive',
+                    },
+                  },
+                  {
+                    region: {
+                      name: {
+                        contains: 'Jane',
+                        mode: 'insensitive',
+                      },
+                    },
+                  },
+                ]),
+              },
+            ],
           },
         }),
       );
-      expect(mockPrismaService.referral.count).toHaveBeenCalledWith({
-        where: {
-          referrerContactName: { startsWith: 'Jane', mode: 'insensitive' },
-        },
-      });
     });
 
     it('should combine search with other filters', async () => {
@@ -540,10 +561,239 @@ describe('ReferralsService', () => {
         expect.objectContaining({
           where: {
             referralStatus: ReferralStatus.OPEN,
-            referrerContactName: { startsWith: 'Smith', mode: 'insensitive' },
+            AND: [
+              {
+                OR: expect.arrayContaining([
+                  {
+                    referrerContactName: {
+                      contains: 'Smith',
+                      mode: 'insensitive',
+                    },
+                  },
+                ]),
+              },
+            ],
           },
         }),
       );
+    });
+
+    it('should apply dynamic sorting when sort params are provided', async () => {
+      mockPrismaService.referral.findMany.mockResolvedValue([]);
+      mockPrismaService.referral.count.mockResolvedValue(0);
+
+      await service.findAll({
+        sortBy: 'referrerContactName',
+        sortOrder: 'asc',
+      });
+
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { referrerContactName: 'asc' },
+        }),
+      );
+    });
+
+    it('should apply relation sorting when sorting by region', async () => {
+      mockPrismaService.referral.findMany.mockResolvedValue([]);
+      mockPrismaService.referral.count.mockResolvedValue(0);
+
+      await service.findAll({ sortBy: 'region', sortOrder: 'asc' });
+
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { region: { name: 'asc' } },
+        }),
+      );
+    });
+
+    it('should apply column contains filter when provided', async () => {
+      mockPrismaService.referral.findMany.mockResolvedValue([]);
+      mockPrismaService.referral.count.mockResolvedValue(0);
+
+      await service.findAll({
+        filterBy: 'individualLastName',
+        filterOperator: 'contains',
+        filterValue: 'smi',
+      });
+
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            AND: [
+              {
+                individualLastName: {
+                  contains: 'smi',
+                  mode: 'insensitive',
+                },
+              },
+            ],
+          },
+        }),
+      );
+    });
+
+    it('should parse and apply boolean filter for flag column', async () => {
+      mockPrismaService.referral.findMany.mockResolvedValue([]);
+      mockPrismaService.referral.count.mockResolvedValue(0);
+
+      await service.findAll({
+        filterBy: 'flag',
+        filterOperator: 'equals',
+        filterValue: 'yes',
+      });
+
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            AND: [{ flag: true }],
+          },
+        }),
+      );
+    });
+
+    it('should reject invalid typed filter values', async () => {
+      await expect(
+        service.findAll({
+          filterBy: 'flag',
+          filterOperator: 'equals',
+          filterValue: 'maybe',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockPrismaService.referral.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should match enum filters by display label', async () => {
+      mockPrismaService.referral.findMany.mockResolvedValue([]);
+      mockPrismaService.referral.count.mockResolvedValue(0);
+
+      await service.findAll({
+        filterBy: 'referralStatus',
+        filterOperator: 'equals',
+        filterValue: 'Contact-Made',
+      });
+
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            AND: [{ referralStatus: ReferralStatus.CONTACT_MADE }],
+          },
+        }),
+      );
+    });
+
+    it('should match support filters by display label', async () => {
+      mockPrismaService.referral.findMany.mockResolvedValue([]);
+      mockPrismaService.referral.count.mockResolvedValue(0);
+
+      await service.findAll({
+        filterBy: 'neededSupports',
+        filterOperator: 'equals',
+        filterValue: 'Income Assistance (Provincial)',
+      });
+
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            AND: [
+              {
+                neededSupports: {
+                  has: 'INCOME_ASSISTANCE_PROVINCIAL',
+                },
+              },
+            ],
+          },
+        }),
+      );
+    });
+
+    it('should match global search by enum display label', async () => {
+      mockPrismaService.referral.findMany.mockResolvedValue([]);
+      mockPrismaService.referral.count.mockResolvedValue(0);
+
+      await service.findAll({ search: 'Nonfinancial Supports Provided' });
+
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            AND: [
+              {
+                OR: expect.arrayContaining([
+                  { referralOutcome: ReferralOutcome.SERVICES_PROVIDED },
+                ]),
+              },
+            ],
+          },
+        }),
+      );
+    });
+
+    it('should reject unsupported array sorting', async () => {
+      await expect(
+        service.findAll({
+          sortBy: 'currentlyConnectedSupports',
+          sortOrder: 'asc',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockPrismaService.referral.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findAllForExport', () => {
+    it('should apply active query criteria and log export audit', async () => {
+      const rows = [createMockReferral()];
+      mockPrismaService.referral.findMany.mockResolvedValue(rows);
+      mockPrismaService.referral.count.mockResolvedValue(1);
+
+      const result = await service.findAllForExport('user-uuid-1', {
+        search: 'smith',
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+        filterBy: 'referralStatus',
+        filterOperator: 'contains',
+        filterValue: 'open',
+      });
+
+      expect(result).toEqual({
+        data: rows,
+        meta: {
+          total: 1,
+          exported: 1,
+          truncated: false,
+          maxRows: 10000,
+        },
+      });
+      expect(mockPrismaService.referral.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.any(Array),
+          }),
+          orderBy: { createdAt: 'desc' },
+        }),
+      );
+      expect(mockAuditService.logGlobal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'EXPORT',
+          userId: 'user-uuid-1',
+        }),
+      );
+    });
+
+    it('should flag truncated exports in metadata', async () => {
+      const rows = [createMockReferral()];
+      mockPrismaService.referral.findMany.mockResolvedValue(rows);
+      mockPrismaService.referral.count.mockResolvedValue(2);
+
+      const result = await service.findAllForExport('user-uuid-1', {});
+
+      expect(result.meta).toEqual({
+        total: 2,
+        exported: 1,
+        truncated: true,
+        maxRows: 10000,
+      });
     });
   });
 

--- a/backend/src/referrals/referrals.service.ts
+++ b/backend/src/referrals/referrals.service.ts
@@ -15,9 +15,15 @@ import {
   ReleaseFromType,
 } from './dto/create-referral.dto';
 import { UpdateReferralDto, ReferralStatus } from './dto/update-referral.dto';
+import { FindAllReferralsDto } from './dto/find-all-referrals.dto';
 import { Referral } from '../generated/prisma/client';
+import {
+  REFERRAL_INCLUDE,
+  buildWhere,
+  buildOrderBy,
+} from './referrals-query.builder';
 
-const TRACKED_FIELDS = [
+const TRACKED_FIELDS: string[] = [
   'referralStatus',
   'referralOutcome',
   'assignedToId',
@@ -59,6 +65,16 @@ const TRACKED_FIELDS = [
   'pendingOrRecentlyReleased',
   'releaseDate',
 ];
+
+export interface ReferralExportResult {
+  data: Referral[];
+  meta: {
+    total: number;
+    exported: number;
+    truncated: boolean;
+    maxRows: number;
+  };
+}
 
 @Injectable()
 export class ReferralsService {
@@ -264,53 +280,23 @@ export class ReferralsService {
       });
   }
 
-  async findAll(params: {
-    page?: number;
-    limit?: number;
-    status?: ReferralStatus;
-    regionId?: string;
-    assignedToId?: string;
-    search?: string;
-  }): Promise<{
+  async findAll(params: FindAllReferralsDto): Promise<{
     data: Referral[];
     meta: { total: number; page: number; limit: number; totalPages: number };
   }> {
-    const {
-      page = 1,
-      limit = 10,
-      status,
-      regionId,
-      assignedToId,
-      search,
-    } = params;
+    const { page = 1, limit = 10 } = params;
     const skip = (page - 1) * limit;
 
-    const where = {
-      ...(status && { referralStatus: status }),
-      ...(regionId && { regionId }),
-      ...(assignedToId && { assignedToId }),
-      ...(search && {
-        referrerContactName: {
-          startsWith: search,
-          mode: 'insensitive' as const,
-        },
-      }),
-    };
+    const where = buildWhere(params);
+    const orderBy = buildOrderBy(params.sortBy, params.sortOrder);
 
     const [data, total] = await Promise.all([
       this.prisma.referral.findMany({
         where,
         skip,
         take: limit,
-        orderBy: {
-          createdAt: 'desc',
-        },
-        include: {
-          region: true,
-          ministry: true,
-          agencyType: true,
-          assignedTo: true,
-        },
+        orderBy,
+        include: REFERRAL_INCLUDE,
       }),
       this.prisma.referral.count({ where }),
     ]);
@@ -326,17 +312,22 @@ export class ReferralsService {
     };
   }
 
-  async findAllForExport(userId?: string): Promise<Referral[]> {
-    const rows = await this.prisma.referral.findMany({
-      take: ReferralsService.EXPORT_MAX_ROWS,
-      orderBy: { createdAt: 'desc' },
-      include: {
-        region: true,
-        ministry: true,
-        agencyType: true,
-        assignedTo: true,
-      },
-    });
+  async findAllForExport(
+    userId?: string,
+    params: FindAllReferralsDto = {},
+  ): Promise<ReferralExportResult> {
+    const where = buildWhere(params);
+    const orderBy = buildOrderBy(params.sortBy, params.sortOrder);
+
+    const [rows, total] = await Promise.all([
+      this.prisma.referral.findMany({
+        where,
+        take: ReferralsService.EXPORT_MAX_ROWS,
+        orderBy,
+        include: REFERRAL_INCLUDE,
+      }),
+      this.prisma.referral.count({ where }),
+    ]);
 
     await this.auditService.logGlobal({
       tableName: 'referral',
@@ -352,7 +343,15 @@ export class ReferralsService {
       userId,
     });
 
-    return rows;
+    return {
+      data: rows,
+      meta: {
+        total,
+        exported: rows.length,
+        truncated: rows.length < total,
+        maxRows: ReferralsService.EXPORT_MAX_ROWS,
+      },
+    };
   }
 
   async findOne(id: string): Promise<Referral> {

--- a/backend/src/referrals/referrals.service.ts
+++ b/backend/src/referrals/referrals.service.ts
@@ -313,7 +313,7 @@ export class ReferralsService {
   }
 
   async findAllForExport(
-    userId?: string,
+    userId: string,
     params: FindAllReferralsDto = {},
   ): Promise<ReferralExportResult> {
     const where = buildWhere(params);


### PR DESCRIPTION
Introduce column header UI (ColumnHeaderMenu) and ColumnFilterPopover with client-side state for sorting and column-scoped filtering; integrate into Referrals page and show export warnings when CSV exports are truncated. Update types (ExportReferralsResponse, SortOrder, FilterOperator, FetchReferralsParams) and make apiService.fetchReferralsForExport accept query params and return metadata. Add/refine referral columns (marking some unsortable). Backend: expand FindAllReferralsDto with sort/filter options, add a referrals-query.builder to build Prisma where/orderBy clauses (including parsing for dates, enums, booleans, numbers, support arrays and global search), and wire controller/service to support export with query params. Add and update unit tests for frontend and backend to cover export truncation, header menu behavior, API export endpoint, search semantics, sorting and filtering behaviors.