### PR TITLE
Add summary workflow, cronjob, and email templates

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,7 +4,11 @@ import { AppModule } from './app.module';
 import { customLogger } from './common/logger.config';
 import type { NestExpressApplication } from '@nestjs/platform-express';
 import helmet from 'helmet';
-import { VersioningType, ValidationPipe } from '@nestjs/common';
+import {
+  type INestApplicationContext,
+  VersioningType,
+  ValidationPipe,
+} from '@nestjs/common';
 
 export function shouldExposeSwagger(nodeEnv = process.env.NODE_ENV): boolean {
   return nodeEnv !== 'production';
@@ -72,4 +76,10 @@ export async function bootstrap() {
   }
 
   return app;
+}
+
+export async function bootstrapApplicationContext(): Promise<INestApplicationContext> {
+  return NestFactory.createApplicationContext(AppModule, {
+    logger: customLogger,
+  });
 }

--- a/backend/src/cron/run-summary.ts
+++ b/backend/src/cron/run-summary.ts
@@ -1,0 +1,51 @@
+import { Logger } from '@nestjs/common';
+import { bootstrapApplicationContext } from '../app';
+import { SummaryWorkflow } from '../email/workflows/summary.workflow';
+import { resolveSummaryWindow } from './summary-window';
+
+const logger = new Logger('SUMMARY_CRON');
+
+async function run(): Promise<void> {
+  const app = await bootstrapApplicationContext();
+
+  try {
+    const workflow = app.get(SummaryWorkflow);
+    const window = resolveSummaryWindow(new Date());
+
+    logger.log(
+      JSON.stringify({
+        event: 'summary_cron_started',
+        runKind: window.runKind,
+        scheduledAt: window.scheduledAt.toISOString(),
+        windowStart: window.windowStart.toISOString(),
+        windowEnd: window.windowEnd.toISOString(),
+      }),
+    );
+
+    const result = await workflow.handle(window);
+
+    logger.log(
+      JSON.stringify({
+        event: 'summary_cron_completed',
+        runKind: window.runKind,
+        scheduledAt: window.scheduledAt.toISOString(),
+        windowStart: window.windowStart.toISOString(),
+        windowEnd: window.windowEnd.toISOString(),
+        ...result,
+      }),
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+run().catch((error: unknown) => {
+  logger.error(
+    JSON.stringify({
+      event: 'summary_cron_failed',
+      errorMessage:
+        error instanceof Error ? error.message : 'Unknown summary cron error',
+    }),
+  );
+  process.exitCode = 1;
+});

--- a/backend/src/cron/summary-window.spec.ts
+++ b/backend/src/cron/summary-window.spec.ts
@@ -1,0 +1,47 @@
+import { resolveSummaryWindow } from './summary-window';
+
+describe('resolveSummaryWindow', () => {
+  it('resolves the morning run window at exactly 7:30am boundary', () => {
+    const window = resolveSummaryWindow(new Date('2026-06-02T14:30:00Z'));
+
+    expect(window.runKind).toBe('morning');
+    expect(window.windowStart.toISOString()).toBe('2026-06-01T21:30:00.000Z');
+    expect(window.windowEnd.toISOString()).toBe('2026-06-02T14:30:00.000Z');
+  });
+
+  it('resolves the afternoon run window at exactly 2:30pm boundary', () => {
+    const window = resolveSummaryWindow(new Date('2026-06-02T21:30:00Z'));
+
+    expect(window.runKind).toBe('afternoon');
+    expect(window.windowStart.toISOString()).toBe('2026-06-02T14:30:00.000Z');
+    expect(window.windowEnd.toISOString()).toBe('2026-06-02T21:30:00.000Z');
+  });
+
+  it('keeps the prior window end exclusive and the next window start inclusive', () => {
+    const morningWindow = resolveSummaryWindow(
+      new Date('2026-06-02T14:30:00Z'),
+    );
+    const afternoonWindow = resolveSummaryWindow(
+      new Date('2026-06-02T21:30:00Z'),
+    );
+    const nextMorningWindow = resolveSummaryWindow(
+      new Date('2026-06-03T14:30:00Z'),
+    );
+
+    const exactMorningBoundary = new Date('2026-06-02T14:30:00Z');
+    const exactAfternoonBoundary = new Date('2026-06-02T21:30:00Z');
+
+    expect(exactMorningBoundary.getTime()).toBe(
+      morningWindow.windowEnd.getTime(),
+    );
+    expect(exactMorningBoundary.getTime()).toBe(
+      afternoonWindow.windowStart.getTime(),
+    );
+    expect(exactAfternoonBoundary.getTime()).toBe(
+      afternoonWindow.windowEnd.getTime(),
+    );
+    expect(exactAfternoonBoundary.getTime()).toBe(
+      nextMorningWindow.windowStart.getTime(),
+    );
+  });
+});

--- a/backend/src/cron/summary-window.ts
+++ b/backend/src/cron/summary-window.ts
@@ -1,0 +1,54 @@
+const SUMMARY_MORNING_HOUR_UTC = 14;
+const SUMMARY_AFTERNOON_HOUR_UTC = 21;
+const SUMMARY_MINUTE_UTC = 30;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type SummaryRunKind = 'morning' | 'afternoon';
+
+export interface SummaryWindow {
+  runKind: SummaryRunKind;
+  scheduledAt: Date;
+  windowStart: Date;
+  windowEnd: Date;
+}
+
+function createUtcTimestamp(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+): Date {
+  return new Date(Date.UTC(year, month, day, hour, SUMMARY_MINUTE_UTC, 0, 0));
+}
+
+export function resolveSummaryWindow(runAt: Date): SummaryWindow {
+  const scheduledAt = new Date(runAt);
+  const morningCutoff = createUtcTimestamp(
+    scheduledAt.getUTCFullYear(),
+    scheduledAt.getUTCMonth(),
+    scheduledAt.getUTCDate(),
+    SUMMARY_MORNING_HOUR_UTC,
+  );
+  const afternoonCutoff = createUtcTimestamp(
+    scheduledAt.getUTCFullYear(),
+    scheduledAt.getUTCMonth(),
+    scheduledAt.getUTCDate(),
+    SUMMARY_AFTERNOON_HOUR_UTC,
+  );
+
+  if (scheduledAt.getTime() >= afternoonCutoff.getTime()) {
+    return {
+      runKind: 'afternoon',
+      scheduledAt,
+      windowStart: morningCutoff,
+      windowEnd: afternoonCutoff,
+    };
+  }
+
+  return {
+    runKind: 'morning',
+    scheduledAt,
+    windowStart: new Date(afternoonCutoff.getTime() - MILLISECONDS_PER_DAY),
+    windowEnd: morningCutoff,
+  };
+}

--- a/backend/src/email/workflows/summary.workflow.spec.ts
+++ b/backend/src/email/workflows/summary.workflow.spec.ts
@@ -1,0 +1,232 @@
+import { Logger } from '@nestjs/common';
+import { SummaryWindow } from '../../cron/summary-window';
+import { MailService } from '../../mailer/mail.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { SummaryWorkflow } from './summary.workflow';
+
+describe('SummaryWorkflow', () => {
+  const window: SummaryWindow = {
+    runKind: 'afternoon',
+    scheduledAt: new Date('2026-06-02T21:30:00Z'),
+    windowStart: new Date('2026-06-02T14:30:00Z'),
+    windowEnd: new Date('2026-06-02T21:30:00Z'),
+  };
+
+  const createReferral = (
+    overrides: Record<string, unknown> = {},
+  ): Record<string, unknown> => ({
+    id: 'ref-123',
+    specificCityTown: 'Prince George',
+    createdAt: new Date('2026-06-02T15:00:00Z'),
+    referralStatus: 'OPEN',
+    flag: false,
+    region: {
+      id: 'region-1',
+      name: 'North',
+      managerEmail: ' manager@test.com ',
+      supervisorEmail: 'supervisor@test.com',
+      assistantSupervisorEmail: 'assistant@test.com',
+      sharedMailboxEmail: 'shared@test.com',
+    },
+    ...overrides,
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('queries referrals with an inclusive start and exclusive end window', async () => {
+    const prisma = {
+      referral: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    } as unknown as PrismaService;
+    const mailService = {
+      sendSummaryNotification: jest.fn().mockResolvedValue(undefined),
+    } as unknown as MailService;
+    const workflow = new SummaryWorkflow(prisma, mailService);
+
+    await workflow.handle(window);
+
+    expect(prisma.referral.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          createdAt: {
+            gte: window.windowStart,
+            lt: window.windowEnd,
+          },
+        },
+      }),
+    );
+  });
+
+  it('groups referrals by region and sends one summary per region', async () => {
+    const prisma = {
+      referral: {
+        findMany: jest.fn().mockResolvedValue([
+          createReferral(),
+          createReferral({
+            id: 'ref-456',
+            specificCityTown: 'Terrace',
+            createdAt: new Date('2026-06-02T16:00:00Z'),
+          }),
+          createReferral({
+            id: 'ref-789',
+            region: {
+              id: 'region-2',
+              name: 'Island',
+              managerEmail: null,
+              supervisorEmail: null,
+              assistantSupervisorEmail: null,
+              sharedMailboxEmail: 'island-shared@test.com',
+            },
+          }),
+        ]),
+      },
+    } as unknown as PrismaService;
+    const mailService = {
+      sendSummaryNotification: jest.fn().mockResolvedValue(undefined),
+    } as unknown as MailService;
+    const workflow = new SummaryWorkflow(prisma, mailService);
+
+    const result = await workflow.handle(window);
+
+    expect(mailService.sendSummaryNotification).toHaveBeenCalledTimes(2);
+    expect(mailService.sendSummaryNotification).toHaveBeenNthCalledWith(
+      1,
+      [
+        'manager@test.com',
+        'supervisor@test.com',
+        'assistant@test.com',
+        'shared@test.com',
+      ],
+      {
+        regionName: 'North',
+        windowStart: window.windowStart,
+        windowEnd: window.windowEnd,
+        rows: [
+          {
+            referralId: 'ref-123',
+            cityTown: 'Prince George',
+            createdAt: new Date('2026-06-02T15:00:00Z'),
+            status: 'OPEN',
+            flagged: false,
+          },
+          {
+            referralId: 'ref-456',
+            cityTown: 'Terrace',
+            createdAt: new Date('2026-06-02T16:00:00Z'),
+            status: 'OPEN',
+            flagged: false,
+          },
+        ],
+      },
+    );
+    expect(mailService.sendSummaryNotification).toHaveBeenNthCalledWith(
+      2,
+      ['island-shared@test.com'],
+      {
+        regionName: 'Island',
+        windowStart: window.windowStart,
+        windowEnd: window.windowEnd,
+        rows: [
+          {
+            referralId: 'ref-789',
+            cityTown: 'Prince George',
+            createdAt: new Date('2026-06-02T15:00:00Z'),
+            status: 'OPEN',
+            flagged: false,
+          },
+        ],
+      },
+    );
+    expect(result).toEqual({
+      totalReferrals: 3,
+      totalRegions: 2,
+      sentRegions: 2,
+      skippedRegions: 0,
+      failedRegions: 0,
+    });
+  });
+
+  it('skips regions with no configured recipients and logs the skip', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    const prisma = {
+      referral: {
+        findMany: jest.fn().mockResolvedValue([
+          createReferral({
+            region: {
+              id: 'region-1',
+              name: 'North',
+              managerEmail: ' ',
+              supervisorEmail: null,
+              assistantSupervisorEmail: null,
+              sharedMailboxEmail: null,
+            },
+          }),
+        ]),
+      },
+    } as unknown as PrismaService;
+    const mailService = {
+      sendSummaryNotification: jest.fn().mockResolvedValue(undefined),
+    } as unknown as MailService;
+    const workflow = new SummaryWorkflow(prisma, mailService);
+
+    const result = await workflow.handle(window);
+
+    expect(mailService.sendSummaryNotification).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"summary_region_skipped"'),
+    );
+    expect(result).toEqual({
+      totalReferrals: 1,
+      totalRegions: 1,
+      sentRegions: 0,
+      skippedRegions: 1,
+      failedRegions: 0,
+    });
+  });
+
+  it('continues processing when one region send fails', async () => {
+    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    const prisma = {
+      referral: {
+        findMany: jest.fn().mockResolvedValue([
+          createReferral(),
+          createReferral({
+            id: 'ref-456',
+            region: {
+              id: 'region-2',
+              name: 'Island',
+              managerEmail: null,
+              supervisorEmail: null,
+              assistantSupervisorEmail: null,
+              sharedMailboxEmail: 'island-shared@test.com',
+            },
+          }),
+        ]),
+      },
+    } as unknown as PrismaService;
+    const mailService = {
+      sendSummaryNotification: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('smtp failure'))
+        .mockResolvedValueOnce(undefined),
+    } as unknown as MailService;
+    const workflow = new SummaryWorkflow(prisma, mailService);
+
+    const result = await workflow.handle(window);
+
+    expect(mailService.sendSummaryNotification).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"summary_region_failed"'),
+    );
+    expect(result).toEqual({
+      totalReferrals: 2,
+      totalRegions: 2,
+      sentRegions: 1,
+      skippedRegions: 0,
+      failedRegions: 1,
+    });
+  });
+});

--- a/backend/src/email/workflows/summary.workflow.ts
+++ b/backend/src/email/workflows/summary.workflow.ts
@@ -1,0 +1,207 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { MailService } from '../../mailer/mail.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { SummaryWindow } from '../../cron/summary-window';
+
+interface RegionRecipients {
+  id: string;
+  name: string;
+  managerEmail: string | null;
+  supervisorEmail: string | null;
+  assistantSupervisorEmail: string | null;
+  sharedMailboxEmail: string | null;
+}
+
+interface SummaryReferral {
+  id: string;
+  specificCityTown: string;
+  createdAt: Date;
+  referralStatus: string;
+  flag: boolean;
+  region: RegionRecipients;
+}
+
+interface RegionSummaryGroup {
+  region: RegionRecipients;
+  rows: SummaryReferral[];
+}
+
+export interface SummaryWorkflowResult {
+  totalReferrals: number;
+  totalRegions: number;
+  sentRegions: number;
+  skippedRegions: number;
+  failedRegions: number;
+}
+
+@Injectable()
+export class SummaryWorkflow {
+  private readonly logger = new Logger('REFERRALS');
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly mailService: MailService,
+  ) {}
+
+  async handle(window: SummaryWindow): Promise<SummaryWorkflowResult> {
+    const referrals = await this.prisma.referral.findMany({
+      where: {
+        createdAt: {
+          gte: window.windowStart,
+          lt: window.windowEnd,
+        },
+      },
+      select: {
+        id: true,
+        specificCityTown: true,
+        createdAt: true,
+        referralStatus: true,
+        flag: true,
+        region: {
+          select: {
+            id: true,
+            name: true,
+            managerEmail: true,
+            supervisorEmail: true,
+            assistantSupervisorEmail: true,
+            sharedMailboxEmail: true,
+          },
+        },
+      },
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    });
+
+    if (referrals.length === 0) {
+      this.log('log', 'summary_run_empty', {
+        runKind: window.runKind,
+        windowStart: window.windowStart.toISOString(),
+        windowEnd: window.windowEnd.toISOString(),
+      });
+      return {
+        totalReferrals: 0,
+        totalRegions: 0,
+        sentRegions: 0,
+        skippedRegions: 0,
+        failedRegions: 0,
+      };
+    }
+
+    const groups = this.groupByRegion(referrals);
+    const result: SummaryWorkflowResult = {
+      totalReferrals: referrals.length,
+      totalRegions: groups.length,
+      sentRegions: 0,
+      skippedRegions: 0,
+      failedRegions: 0,
+    };
+
+    for (const group of groups) {
+      const recipients = this.resolveRecipients(group.region);
+      if (recipients.length === 0) {
+        result.skippedRegions += 1;
+        this.log('warn', 'summary_region_skipped', {
+          regionId: group.region.id,
+          regionName: group.region.name,
+          reason: 'missing_recipients',
+          windowStart: window.windowStart.toISOString(),
+          windowEnd: window.windowEnd.toISOString(),
+        });
+        continue;
+      }
+
+      try {
+        await this.mailService.sendSummaryNotification(recipients, {
+          regionName: group.region.name,
+          windowStart: window.windowStart,
+          windowEnd: window.windowEnd,
+          rows: group.rows.map((referral) => ({
+            referralId: referral.id,
+            cityTown: referral.specificCityTown,
+            createdAt: referral.createdAt,
+            status: referral.referralStatus,
+            flagged: referral.flag,
+          })),
+        });
+        result.sentRegions += 1;
+        this.log('log', 'summary_region_sent', {
+          regionId: group.region.id,
+          regionName: group.region.name,
+          recipientCount: recipients.length,
+          referralCount: group.rows.length,
+          windowStart: window.windowStart.toISOString(),
+          windowEnd: window.windowEnd.toISOString(),
+        });
+      } catch (error) {
+        result.failedRegions += 1;
+        this.log('error', 'summary_region_failed', {
+          regionId: group.region.id,
+          regionName: group.region.name,
+          recipientCount: recipients.length,
+          referralCount: group.rows.length,
+          windowStart: window.windowStart.toISOString(),
+          windowEnd: window.windowEnd.toISOString(),
+          errorMessage:
+            error instanceof Error ? error.message : 'Unknown summary error',
+        });
+      }
+    }
+
+    this.log('log', 'summary_run_completed', {
+      runKind: window.runKind,
+      windowStart: window.windowStart.toISOString(),
+      windowEnd: window.windowEnd.toISOString(),
+      ...result,
+    });
+
+    return result;
+  }
+
+  private groupByRegion(referrals: SummaryReferral[]): RegionSummaryGroup[] {
+    const groups = new Map<string, RegionSummaryGroup>();
+
+    for (const referral of referrals) {
+      const existing = groups.get(referral.region.id);
+      if (existing) {
+        existing.rows.push(referral);
+        continue;
+      }
+
+      groups.set(referral.region.id, {
+        region: referral.region,
+        rows: [referral],
+      });
+    }
+
+    return Array.from(groups.values());
+  }
+
+  private resolveRecipients(region: RegionRecipients): string[] {
+    return Array.from(
+      new Set(
+        [
+          region.managerEmail,
+          region.supervisorEmail,
+          region.assistantSupervisorEmail,
+          region.sharedMailboxEmail,
+        ]
+          .map((email) => email?.trim())
+          .filter((email): email is string => Boolean(email)),
+      ),
+    );
+  }
+
+  private log(
+    level: 'log' | 'warn' | 'error',
+    event: string,
+    details: Record<string, unknown>,
+  ): void {
+    const payload = JSON.stringify({ event, ...details });
+
+    if (level === 'error') {
+      this.logger.error(payload);
+      return;
+    }
+
+    this.logger[level](payload);
+  }
+}

--- a/backend/src/mailer/mail.service.spec.ts
+++ b/backend/src/mailer/mail.service.spec.ts
@@ -101,6 +101,24 @@ describe('MailService', () => {
       });
       expect(sendMail).not.toHaveBeenCalled();
     });
+
+    it('does not send summary notification when disabled', async () => {
+      await service.sendSummaryNotification(['shared@test'], {
+        regionName: 'North',
+        windowStart: new Date('2026-06-01T14:30:00Z'),
+        windowEnd: new Date('2026-06-01T21:30:00Z'),
+        rows: [
+          {
+            referralId: 'ref-123',
+            cityTown: 'Vancouver',
+            createdAt: baseReferral.createdAt,
+            status: 'OPEN',
+            flagged: false,
+          },
+        ],
+      });
+      expect(sendMail).not.toHaveBeenCalled();
+    });
   });
 
   describe('sendAutomaticReply', () => {
@@ -169,6 +187,42 @@ describe('MailService', () => {
       const args = sendMail.mock.calls[0][0];
       expect(args.to).toHaveLength(4);
       expect(args.subject).toMatch(/^URGENT Referral/);
+    });
+  });
+
+  describe('sendSummaryNotification', () => {
+    it('renders a regional summary using the admin referral URL base', async () => {
+      await service.sendSummaryNotification(['shared@test', 'mgr@test'], {
+        regionName: 'North',
+        windowStart: new Date('2026-06-01T14:30:00Z'),
+        windowEnd: new Date('2026-06-01T21:30:00Z'),
+        rows: [
+          {
+            referralId: 'ref-123',
+            cityTown: 'Vancouver',
+            createdAt: baseReferral.createdAt,
+            status: 'OPEN',
+            flagged: false,
+          },
+          {
+            referralId: 'ref-456',
+            cityTown: 'Victoria',
+            createdAt: new Date('2026-04-21T16:00:00Z'),
+            status: 'ASSIGNED',
+            flagged: true,
+          },
+        ],
+      });
+
+      expect(sendMail).toHaveBeenCalledTimes(1);
+      const args = sendMail.mock.calls[0][0];
+      expect(args.to).toEqual(['shared@test', 'mgr@test']);
+      expect(args.subject).toContain('Referral summary: North');
+      expect(args.html).toContain('https://admin.test/referrals/ref-123');
+      expect(args.html).toContain('https://admin.test/referrals/ref-456');
+      expect(args.text).toContain(
+        'Window (UTC): 2026-06-01T14:30:00Z to 2026-06-01T21:30:00Z',
+      );
     });
   });
 

--- a/backend/src/mailer/mail.service.spec.ts
+++ b/backend/src/mailer/mail.service.spec.ts
@@ -217,12 +217,37 @@ describe('MailService', () => {
       expect(sendMail).toHaveBeenCalledTimes(1);
       const args = sendMail.mock.calls[0][0];
       expect(args.to).toEqual(['shared@test', 'mgr@test']);
-      expect(args.subject).toContain('Referral summary: North');
+      expect(args.subject).toBe('PM Referral Summary - 2026-06-01T14:30');
       expect(args.html).toContain('https://admin.test/referrals/ref-123');
       expect(args.html).toContain('https://admin.test/referrals/ref-456');
       expect(args.text).toContain(
-        'Window (UTC): 2026-06-01T14:30:00Z to 2026-06-01T21:30:00Z',
+        'Your team has received the following referrals:',
       );
+      expect(args.html).toContain(
+        'Your team has received the following referrals:',
+      );
+      expect(args.text).toContain('Please attend to accordingly');
+      expect(args.html).toContain('Please attend to accordingly');
+    });
+
+    it('uses AM subject line for the morning run window end', async () => {
+      await service.sendSummaryNotification(['shared@test'], {
+        regionName: 'North',
+        windowStart: new Date('2026-06-01T21:30:00Z'),
+        windowEnd: new Date('2026-06-02T14:30:00Z'),
+        rows: [
+          {
+            referralId: 'ref-123',
+            cityTown: 'Vancouver',
+            createdAt: baseReferral.createdAt,
+            status: 'OPEN',
+            flagged: false,
+          },
+        ],
+      });
+
+      const args = sendMail.mock.calls[0][0];
+      expect(args.subject).toBe('AM Referral Summary - 2026-06-02T07:30');
     });
   });
 

--- a/backend/src/mailer/mail.service.ts
+++ b/backend/src/mailer/mail.service.ts
@@ -12,6 +12,10 @@ import {
   renderRegionChangeNotification,
 } from './templates/region-change-notification';
 import {
+  SummaryNotificationParams,
+  renderSummaryNotification,
+} from './templates/summary-notification';
+import {
   UrgentNotificationParams,
   renderUrgentNotification,
 } from './templates/urgent-notification';
@@ -55,7 +59,9 @@ export class MailService {
     data: Omit<AssignmentNotificationParams, 'referralUrl'>,
   ): Promise<void> {
     if (
-      this.skipIfDisabled(`assignment notification for referral ${data.referralId}`)
+      this.skipIfDisabled(
+        `assignment notification for referral ${data.referralId}`,
+      )
     )
       return;
     const referralUrl = `${this.mailConfig.getAdminAppUrl()}/referrals/${data.referralId}`;
@@ -109,6 +115,27 @@ export class MailService {
 
     this.logger.log(
       `Region change notification sent for referral ${data.referralId} to ${to.length} recipients (messageId=${info.messageId})`,
+    );
+  }
+
+  async sendSummaryNotification(
+    to: string[],
+    data: Omit<SummaryNotificationParams, 'referralUrlBase'>,
+  ): Promise<void> {
+    if (
+      this.skipIfDisabled(
+        `summary notification for region ${data.regionName} (${data.rows.length} referrals)`,
+      )
+    )
+      return;
+    const { subject, text, html } = renderSummaryNotification({
+      ...data,
+      referralUrlBase: `${this.mailConfig.getAdminAppUrl()}/referrals`,
+    });
+    const info = await this.sendRenderedEmail(to, { subject, text, html });
+
+    this.logger.log(
+      `Summary notification sent for region ${data.regionName} to ${to.length} recipients covering ${data.rows.length} referrals (messageId=${info.messageId})`,
     );
   }
 

--- a/backend/src/mailer/templates/summary-notification.ts
+++ b/backend/src/mailer/templates/summary-notification.ts
@@ -5,7 +5,6 @@ import {
   renderReferralSummaryHtmlTable,
   renderReferralSummaryTextLines,
 } from './referral-summary-table';
-import { escapeHtml } from '../utils/escape-html';
 
 export interface SummaryNotificationRow
   extends Omit<ReferralSummaryRow, 'referralUrl'> {}
@@ -18,8 +17,17 @@ export interface SummaryNotificationParams {
   rows: SummaryNotificationRow[];
 }
 
-function formatUtcTimestamp(value: Date): string {
-  return value.toISOString().replace('.000Z', 'Z');
+const PERMANENT_VANCOUVER_OFFSET_MS = 7 * 60 * 60 * 1000;
+
+function toVancouverTimestamp(value: Date): string {
+  return new Date(value.getTime() - PERMANENT_VANCOUVER_OFFSET_MS)
+    .toISOString()
+    .slice(0, 16);
+}
+
+function toSummaryLabel(windowEnd: Date): 'AM' | 'PM' {
+  const localHour = Number(toVancouverTimestamp(windowEnd).slice(11, 13));
+  return localHour < 12 ? 'AM' : 'PM';
 }
 
 function buildSummaryRow(
@@ -35,39 +43,37 @@ function buildSummaryRow(
 export function renderSummaryNotification(
   params: SummaryNotificationParams,
 ): RenderedEmail {
-  const windowLabel = `${formatUtcTimestamp(params.windowStart)} to ${formatUtcTimestamp(params.windowEnd)}`;
+  const runLabel = toSummaryLabel(params.windowEnd);
+  const runTimestamp = toVancouverTimestamp(params.windowEnd);
   const formattedRows = params.rows.map((row) =>
     buildSummaryRow(row, params.referralUrlBase),
   );
 
-  const subject = `Referral summary: ${params.regionName} (${formattedRows.length})`;
+  const subject = `${runLabel} Referral Summary - ${runTimestamp}`;
 
   const text = [
     'Hello,',
     '',
-    `Referral summary for region: ${params.regionName}`,
-    `Window (UTC): ${windowLabel}`,
-    `Total referrals: ${formattedRows.length}`,
+    'Your team has received the following referrals:',
     '',
-    ...formattedRows.flatMap((row, index) => [
-      `Referral ${index + 1}`,
+    ...formattedRows.flatMap((row) => [
       ...renderReferralSummaryTextLines(row),
       '',
     ]),
+    'Please attend to accordingly',
   ].join('\n');
 
   const html = `
     <p>Hello,</p>
-    <p>Referral summary for region: <strong>${escapeHtml(params.regionName)}</strong></p>
-    <p>Window (UTC): ${escapeHtml(windowLabel)}<br/>Total referrals: ${formattedRows.length}</p>
+    <p>Your team has received the following referrals:</p>
     ${formattedRows
       .map(
-        (row, index) => `
-          <h3>Referral ${index + 1}</h3>
+        (row) => `
           ${renderReferralSummaryHtmlTable(row)}
         `,
       )
       .join('')}
+    <p>Please attend to accordingly</p>
   `.trim();
 
   return { subject, text, html };

--- a/backend/src/mailer/templates/summary-notification.ts
+++ b/backend/src/mailer/templates/summary-notification.ts
@@ -1,0 +1,74 @@
+import type { RenderedEmail } from './automatic-reply';
+import {
+  ReferralSummaryRow,
+  formatReferralSummary,
+  renderReferralSummaryHtmlTable,
+  renderReferralSummaryTextLines,
+} from './referral-summary-table';
+import { escapeHtml } from '../utils/escape-html';
+
+export interface SummaryNotificationRow
+  extends Omit<ReferralSummaryRow, 'referralUrl'> {}
+
+export interface SummaryNotificationParams {
+  regionName: string;
+  windowStart: Date;
+  windowEnd: Date;
+  referralUrlBase: string;
+  rows: SummaryNotificationRow[];
+}
+
+function formatUtcTimestamp(value: Date): string {
+  return value.toISOString().replace('.000Z', 'Z');
+}
+
+function buildSummaryRow(
+  row: SummaryNotificationRow,
+  referralUrlBase: string,
+): ReturnType<typeof formatReferralSummary> {
+  return formatReferralSummary({
+    ...row,
+    referralUrl: `${referralUrlBase}/${row.referralId}`,
+  });
+}
+
+export function renderSummaryNotification(
+  params: SummaryNotificationParams,
+): RenderedEmail {
+  const windowLabel = `${formatUtcTimestamp(params.windowStart)} to ${formatUtcTimestamp(params.windowEnd)}`;
+  const formattedRows = params.rows.map((row) =>
+    buildSummaryRow(row, params.referralUrlBase),
+  );
+
+  const subject = `Referral summary: ${params.regionName} (${formattedRows.length})`;
+
+  const text = [
+    'Hello,',
+    '',
+    `Referral summary for region: ${params.regionName}`,
+    `Window (UTC): ${windowLabel}`,
+    `Total referrals: ${formattedRows.length}`,
+    '',
+    ...formattedRows.flatMap((row, index) => [
+      `Referral ${index + 1}`,
+      ...renderReferralSummaryTextLines(row),
+      '',
+    ]),
+  ].join('\n');
+
+  const html = `
+    <p>Hello,</p>
+    <p>Referral summary for region: <strong>${escapeHtml(params.regionName)}</strong></p>
+    <p>Window (UTC): ${escapeHtml(windowLabel)}<br/>Total referrals: ${formattedRows.length}</p>
+    ${formattedRows
+      .map(
+        (row, index) => `
+          <h3>Referral ${index + 1}</h3>
+          ${renderReferralSummaryHtmlTable(row)}
+        `,
+      )
+      .join('')}
+  `.trim();
+
+  return { subject, text, html };
+}

--- a/backend/src/referrals/referrals.module.ts
+++ b/backend/src/referrals/referrals.module.ts
@@ -4,6 +4,7 @@ import { ReferralsService } from './referrals.service';
 import { AuditModule } from '../audit/audit.module';
 import { AutomaticReplyWorkflow } from '../email/workflows/automatic-reply.workflow';
 import { AssignmentNotificationWorkflow } from '../email/workflows/assignment-notification.workflow';
+import { SummaryWorkflow } from '../email/workflows/summary.workflow';
 import { UrgentNotificationWorkflow } from '../email/workflows/urgent-notification.workflow';
 import { RegionChangeWorkflow } from '../email/workflows/region-change.workflow';
 
@@ -14,6 +15,7 @@ import { RegionChangeWorkflow } from '../email/workflows/region-change.workflow'
     ReferralsService,
     AutomaticReplyWorkflow,
     AssignmentNotificationWorkflow,
+    SummaryWorkflow,
     UrgentNotificationWorkflow,
     RegionChangeWorkflow,
   ],

--- a/helm/backend/templates/cronjob.yaml
+++ b/helm/backend/templates/cronjob.yaml
@@ -1,0 +1,138 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cisb-referral-backend-summary
+  labels:
+    app.kubernetes.io/name: cisb-referral-backend-summary
+spec:
+  schedule: "30 14,21 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: cisb-referral-backend-summary
+        spec:
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          imagePullSecrets:
+            - name: github-docker-registry
+          containers:
+            - name: cisb-referral-backend-summary
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ['node', 'dist/cron/run-summary.js']
+              env:
+                - name: NODE_ENV
+                  value: {{ .Values.nodeEnv | quote }}
+                - name: LOG_LEVEL
+                  value: {{ .Values.logLevel | quote }}
+                - name: POSTGRES_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.crunchySecret }}
+                      key: pgbouncer-host
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.crunchySecret }}
+                      key: user
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.crunchySecret }}
+                      key: password
+                - name: POSTGRES_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.crunchySecret }}
+                      key: pgbouncer-port
+                - name: POSTGRES_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.crunchySecret }}
+                      key: dbname
+                - name: PGBOUNCER_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.crunchySecret }}
+                      key: pgbouncer-uri
+                      optional: true
+                - name: ADMIN_KC_ISSUER_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: ADMIN_KC_ISSUER_URL
+                - name: ADMIN_KC_AUDIENCE
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: ADMIN_KC_AUDIENCE
+                - name: REFERRAL_KC_ISSUER_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: REFERRAL_KC_ISSUER_URL
+                - name: REFERRAL_KC_AUDIENCE
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: REFERRAL_KC_AUDIENCE
+                - name: MAIL_ENABLED
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: MAIL_ENABLED
+                      optional: true
+                - name: SMTP_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: SMTP_HOST
+                - name: SMTP_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: SMTP_PORT
+                - name: SMTP_SECURE
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: SMTP_SECURE
+                - name: SMTP_FROM
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: SMTP_FROM
+                - name: SMTP_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: SMTP_USER
+                      optional: true
+                - name: SMTP_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: SMTP_PASSWORD
+                      optional: true
+                - name: ADMIN_APP_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: cisb-referral-backend-secrets
+                      key: ADMIN_APP_URL
+              {{- with .Values.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          restartPolicy: Never

--- a/helm/backend/templates/cronjob.yaml
+++ b/helm/backend/templates/cronjob.yaml
@@ -11,6 +11,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         metadata:
           labels:


### PR DESCRIPTION
Introduce a scheduled regional referral summary feature:

- Add bootstrapApplicationContext to app.ts for non-HTTP cron context.
- New cron entrypoint (run-summary.ts) that boots the app context, resolves the summary window, runs SummaryWorkflow, and logs results/errors.
- Implement summary window logic (summary-window.ts) with unit tests to determine morning/afternoon windows and inclusive/exclusive boundaries.
- Add SummaryWorkflow to query referrals in the window, group by region, resolve recipients, send summary emails, and emit structured logs; includes unit tests for grouping, skipping, and error handling.
- Extend MailService with sendSummaryNotification and a new summary email template (summary-notification.ts) that renders text/html and referral links using the admin URL base; update mail service tests.
- Register SummaryWorkflow in referrals.module and add a Helm CronJob template (cronjob.yaml) to schedule runs at 14:30 and 21:30 UTC.

The change adds tests for the new logic and ensures cron jobs can run in an application context without starting an HTTP server.