### PR TITLE
Add unit tests for auth and settings modules

### DIFF
--- a/backend/src/auth/config/keycloak.config.spec.ts
+++ b/backend/src/auth/config/keycloak.config.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { KeycloakConfigService } from './keycloak.config';
+
+describe('KeycloakConfigService', () => {
+  let service: KeycloakConfigService;
+
+  const configValues: Record<string, string> = {
+    ADMIN_KC_ISSUER_URL: 'https://admin.example.com/realms/admin/',
+    ADMIN_KC_AUDIENCE: 'admin',
+    REFERRAL_KC_ISSUER_URL: 'https://referral.example.com/realms/referral',
+    REFERRAL_KC_AUDIENCE: 'referral',
+  };
+
+  const mockConfigService = {
+    getOrThrow: jest.fn((key: string) => {
+      const value = configValues[key];
+      if (!value) {
+        throw new Error(`Missing config: ${key}`);
+      }
+      return value;
+    }),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KeycloakConfigService,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<KeycloakConfigService>(KeycloakConfigService);
+    jest.clearAllMocks();
+  });
+
+  describe('getAdminConfig', () => {
+    it('should return admin realm configuration with normalized jwks uri', () => {
+      const result = service.getAdminConfig();
+
+      expect(result).toEqual({
+        issuerUrl: 'https://admin.example.com/realms/admin/',
+        audience: 'admin',
+        jwksUri:
+          'https://admin.example.com/realms/admin/protocol/openid-connect/certs',
+      });
+      expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
+        'ADMIN_KC_ISSUER_URL',
+      );
+      expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
+        'ADMIN_KC_AUDIENCE',
+      );
+    });
+  });
+
+  describe('getReferralConfig', () => {
+    it('should return referral realm configuration with jwks uri', () => {
+      const result = service.getReferralConfig();
+
+      expect(result).toEqual({
+        issuerUrl: 'https://referral.example.com/realms/referral',
+        audience: 'referral',
+        jwksUri:
+          'https://referral.example.com/realms/referral/protocol/openid-connect/certs',
+      });
+      expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
+        'REFERRAL_KC_ISSUER_URL',
+      );
+      expect(mockConfigService.getOrThrow).toHaveBeenCalledWith(
+        'REFERRAL_KC_AUDIENCE',
+      );
+    });
+  });
+
+  describe('missing config handling', () => {
+    it('should throw when required config value is missing', () => {
+      mockConfigService.getOrThrow.mockImplementation((key: string) => {
+        if (key === 'ADMIN_KC_AUDIENCE') {
+          throw new Error('Missing config: ADMIN_KC_AUDIENCE');
+        }
+        return configValues[key];
+      });
+
+      expect(() => service.getAdminConfig()).toThrow(
+        'Missing config: ADMIN_KC_AUDIENCE',
+      );
+    });
+  });
+});

--- a/backend/src/auth/decorators/current-user.decorator.spec.ts
+++ b/backend/src/auth/decorators/current-user.decorator.spec.ts
@@ -1,0 +1,70 @@
+import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
+import { ExecutionContext } from '@nestjs/common';
+import { CurrentContact } from './current-contact.decorator';
+import { CurrentUser } from './current-user.decorator';
+
+const getParamDecoratorFactory = (
+  decorator: (...args: any[]) => ParameterDecorator,
+) => {
+  class TestClass {
+    public testMethod(
+      @decorator() // eslint-disable-line @typescript-eslint/no-unused-vars
+      _value: unknown,
+    ): void {
+      // Method body intentionally unused; only metadata is required for the test.
+    }
+  }
+
+  const metadata = Reflect.getMetadata(
+    ROUTE_ARGS_METADATA,
+    TestClass,
+    'testMethod',
+  );
+  const key = Object.keys(metadata)[0];
+
+  return metadata[key].factory as (
+    data: unknown,
+    ctx: ExecutionContext,
+  ) => unknown;
+};
+
+describe('Auth decorators', () => {
+  describe('CurrentUser', () => {
+    it('should extract user from request', () => {
+      const currentUserFactory = getParamDecoratorFactory(CurrentUser);
+      const requestUser = { id: 'user-1', email: 'user@test.com' };
+      const context = {
+        switchToHttp: () => ({
+          getRequest: () => ({ user: requestUser }),
+        }),
+      } as ExecutionContext;
+
+      const result = currentUserFactory(undefined, context);
+
+      expect(result).toEqual(requestUser);
+    });
+  });
+
+  describe('CurrentContact', () => {
+    it('should extract contact auth payload from request', () => {
+      const currentContactFactory = getParamDecoratorFactory(CurrentContact);
+      const requestContact = {
+        contact: {
+          id: 'contact-1',
+          fullName: 'Contact Name',
+          email: 'contact@test.com',
+        },
+        isProfileComplete: true,
+      };
+      const context = {
+        switchToHttp: () => ({
+          getRequest: () => ({ user: requestContact }),
+        }),
+      } as ExecutionContext;
+
+      const result = currentContactFactory(undefined, context);
+
+      expect(result).toEqual(requestContact);
+    });
+  });
+});

--- a/backend/src/auth/decorators/current-user.decorator.spec.ts
+++ b/backend/src/auth/decorators/current-user.decorator.spec.ts
@@ -1,53 +1,49 @@
-import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
 import { ExecutionContext } from '@nestjs/common';
-import { CurrentContact } from './current-contact.decorator';
 import { CurrentUser } from './current-user.decorator';
+import { CurrentContact } from './current-contact.decorator';
 
-const getParamDecoratorFactory = (
-  decorator: (...args: any[]) => ParameterDecorator,
-) => {
-  class TestClass {
-    public testMethod(
-      @decorator() // eslint-disable-line @typescript-eslint/no-unused-vars
-      _value: unknown,
-    ): void {
-      // Method body intentionally unused; only metadata is required for the test.
-    }
-  }
+// Mocking createParamDecorator to return the inner factory directly avoids
+// relying on Reflect metadata internals or @nestjs/common/constants private paths.
+jest.mock('@nestjs/common', () => ({
+  ...jest.requireActual('@nestjs/common'),
+  createParamDecorator: (factory: (data: unknown, ctx: unknown) => unknown) =>
+    factory,
+}));
 
-  const metadata = Reflect.getMetadata(
-    ROUTE_ARGS_METADATA,
-    TestClass,
-    'testMethod',
-  );
-  const key = Object.keys(metadata)[0];
+type DecoratorFactory = (data: unknown, ctx: ExecutionContext) => unknown;
 
-  return metadata[key].factory as (
-    data: unknown,
-    ctx: ExecutionContext,
-  ) => unknown;
-};
+const createMockContext = (user: unknown): ExecutionContext =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+  }) as ExecutionContext;
 
 describe('Auth decorators', () => {
   describe('CurrentUser', () => {
     it('should extract user from request', () => {
-      const currentUserFactory = getParamDecoratorFactory(CurrentUser);
       const requestUser = { id: 'user-1', email: 'user@test.com' };
-      const context = {
-        switchToHttp: () => ({
-          getRequest: () => ({ user: requestUser }),
-        }),
-      } as ExecutionContext;
 
-      const result = currentUserFactory(undefined, context);
+      const result = (CurrentUser as unknown as DecoratorFactory)(
+        undefined,
+        createMockContext(requestUser),
+      );
 
-      expect(result).toEqual(requestUser);
+      expect(result).toBe(requestUser);
+    });
+
+    it('should return undefined when request user is missing', () => {
+      const result = (CurrentUser as unknown as DecoratorFactory)(
+        undefined,
+        createMockContext(undefined),
+      );
+
+      expect(result).toBeUndefined();
     });
   });
 
   describe('CurrentContact', () => {
     it('should extract contact auth payload from request', () => {
-      const currentContactFactory = getParamDecoratorFactory(CurrentContact);
       const requestContact = {
         contact: {
           id: 'contact-1',
@@ -56,15 +52,13 @@ describe('Auth decorators', () => {
         },
         isProfileComplete: true,
       };
-      const context = {
-        switchToHttp: () => ({
-          getRequest: () => ({ user: requestContact }),
-        }),
-      } as ExecutionContext;
 
-      const result = currentContactFactory(undefined, context);
+      const result = (CurrentContact as unknown as DecoratorFactory)(
+        undefined,
+        createMockContext(requestContact),
+      );
 
-      expect(result).toEqual(requestContact);
+      expect(result).toBe(requestContact);
     });
   });
 });

--- a/backend/src/settings/settings.controller.spec.ts
+++ b/backend/src/settings/settings.controller.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SettingsController } from './settings.controller';
+import { SettingsService } from './settings.service';
+
+const mockSettingsService = {
+  getAdminColumns: jest.fn(),
+  setAdminColumns: jest.fn(),
+};
+
+describe('SettingsController', () => {
+  let controller: SettingsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SettingsController],
+      providers: [
+        {
+          provide: SettingsService,
+          useValue: mockSettingsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SettingsController>(SettingsController);
+    jest.clearAllMocks();
+  });
+
+  describe('getAdminColumns', () => {
+    it('should return columns from service', async () => {
+      const columns = ['flag', 'createdAt'];
+      mockSettingsService.getAdminColumns.mockResolvedValue(columns);
+
+      const result = await controller.getAdminColumns();
+
+      expect(result).toEqual({ columns });
+      expect(mockSettingsService.getAdminColumns).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setAdminColumns', () => {
+    it('should delegate to service with dto columns and current user id', async () => {
+      const user = { id: 'user-1' };
+      const dto = { columns: ['flag', 'assignedTo'] };
+      mockSettingsService.setAdminColumns.mockResolvedValue(dto.columns);
+
+      const result = await controller.setAdminColumns(dto, user as any);
+
+      expect(result).toEqual({ columns: dto.columns });
+      expect(mockSettingsService.setAdminColumns).toHaveBeenCalledWith(
+        dto.columns,
+        'user-1',
+      );
+    });
+  });
+});

--- a/backend/src/settings/settings.service.spec.ts
+++ b/backend/src/settings/settings.service.spec.ts
@@ -1,0 +1,139 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SettingsService } from './settings.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+const mockPrismaService = {
+  appSetting: {
+    findUnique: jest.fn(),
+    upsert: jest.fn(),
+  },
+};
+
+const DEFAULT_ADMIN_COLUMNS = [
+  'flag',
+  'createdAt',
+  'referrerContactName',
+  'referredBy',
+  'referralStatus',
+  'referralOutcome',
+  'individualFirstName',
+  'individualLastName',
+  'region',
+  'specificCityTown',
+  'assignedTo',
+];
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SettingsService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SettingsService>(SettingsService);
+    jest.clearAllMocks();
+  });
+
+  describe('getAdminColumns', () => {
+    it('should return defaults when setting does not exist', async () => {
+      mockPrismaService.appSetting.findUnique.mockResolvedValue(null);
+
+      const result = await service.getAdminColumns();
+
+      expect(result).toEqual(DEFAULT_ADMIN_COLUMNS);
+      expect(mockPrismaService.appSetting.findUnique).toHaveBeenCalledWith({
+        where: { key: 'referrals.adminColumns' },
+      });
+    });
+
+    it('should return persisted columns when value is a string array', async () => {
+      const storedColumns = ['flag', 'assignedTo'];
+      mockPrismaService.appSetting.findUnique.mockResolvedValue({
+        key: 'referrals.adminColumns',
+        value: storedColumns,
+      });
+
+      const result = await service.getAdminColumns();
+
+      expect(result).toEqual(storedColumns);
+    });
+
+    it('should return defaults when persisted value is not an array', async () => {
+      mockPrismaService.appSetting.findUnique.mockResolvedValue({
+        key: 'referrals.adminColumns',
+        value: 'not-an-array',
+      });
+
+      const result = await service.getAdminColumns();
+
+      expect(result).toEqual(DEFAULT_ADMIN_COLUMNS);
+    });
+
+    it('should return defaults when array contains non-string values', async () => {
+      mockPrismaService.appSetting.findUnique.mockResolvedValue({
+        key: 'referrals.adminColumns',
+        value: ['flag', 1000],
+      });
+
+      const result = await service.getAdminColumns();
+
+      expect(result).toEqual(DEFAULT_ADMIN_COLUMNS);
+    });
+  });
+
+  describe('setAdminColumns', () => {
+    it('should upsert columns and include updatedBy when user id exists', async () => {
+      const columns = ['flag', 'createdAt'];
+      mockPrismaService.appSetting.upsert.mockResolvedValue({
+        key: 'referrals.adminColumns',
+        value: columns,
+      });
+
+      const result = await service.setAdminColumns(columns, 'user-1');
+
+      expect(result).toEqual(columns);
+      expect(mockPrismaService.appSetting.upsert).toHaveBeenCalledWith({
+        where: { key: 'referrals.adminColumns' },
+        create: {
+          key: 'referrals.adminColumns',
+          value: columns,
+          updatedBy: 'user-1',
+        },
+        update: {
+          value: columns,
+          updatedBy: 'user-1',
+        },
+      });
+    });
+
+    it('should upsert columns with updatedBy undefined when user id is missing', async () => {
+      const columns = ['flag', 'createdAt'];
+      mockPrismaService.appSetting.upsert.mockResolvedValue({
+        key: 'referrals.adminColumns',
+        value: columns,
+      });
+
+      await service.setAdminColumns(columns);
+
+      expect(mockPrismaService.appSetting.upsert).toHaveBeenCalledWith({
+        where: { key: 'referrals.adminColumns' },
+        create: {
+          key: 'referrals.adminColumns',
+          value: columns,
+          updatedBy: undefined,
+        },
+        update: {
+          value: columns,
+          updatedBy: undefined,
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add Jest unit tests covering KeycloakConfigService, CurrentUser/CurrentContact decorators, SettingsController, and SettingsService. Tests validate Keycloak config normalization and missing-config errors, parameter decorators extracting user/contact payloads from requests, controller delegation to SettingsService, and SettingsService behavior for default vs persisted admin columns and upsert logic (including updatedBy handling). ConfigService and PrismaService are mocked to isolate behavior and exercise edge cases.