### PR TITLE
feat: add assignable-users endpoint and client

### DIFF
--- a/admin-app/src/__tests__/services/api.service.test.ts
+++ b/admin-app/src/__tests__/services/api.service.test.ts
@@ -393,6 +393,20 @@ describe("APIService methods", () => {
       expect(result).toEqual(mockUsers);
     });
 
+    it("should fetch assignable users", async () => {
+      // Arrange
+      const mockUsers = [{ id: "1", name: "User A", isActive: true }];
+      mockGet.mockResolvedValue({ data: mockUsers });
+      const { apiService } = await import("../../services/api");
+
+      // Act
+      const result = await apiService.fetchAssignableUsers();
+
+      // Assert
+      expect(mockGet).toHaveBeenCalledWith("/users/assignees");
+      expect(result).toEqual(mockUsers);
+    });
+
     it("should create a user", async () => {
       // Arrange
       const createData = { email: "user@gov.bc.ca", name: "New User" };

--- a/admin-app/src/pages/ReferralDetail.tsx
+++ b/admin-app/src/pages/ReferralDetail.tsx
@@ -41,8 +41,8 @@ export function ReferralDetail() {
   });
 
   const { data: users = [] } = useQuery({
-    queryKey: ["users"],
-    queryFn: () => apiService.fetchUsers(),
+    queryKey: ["assignable-users"],
+    queryFn: () => apiService.fetchAssignableUsers(),
   });
 
   if (isLoading) {

--- a/admin-app/src/services/api.ts
+++ b/admin-app/src/services/api.ts
@@ -189,6 +189,11 @@ class APIService {
     return response.data;
   }
 
+  async fetchAssignableUsers(): Promise<User[]> {
+    const response = await this.client.get<User[]>("/users/assignees");
+    return response.data;
+  }
+
   async createUser(data: CreateUserDto): Promise<User> {
     const response = await this.client.post<User>("/users", data);
     return response.data;

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -6,6 +6,7 @@ import { UserRole } from '../generated/prisma/client';
 const mockUsersService = {
   create: jest.fn(),
   findAll: jest.fn(),
+  findAssignableUsers: jest.fn(),
   findOne: jest.fn(),
   update: jest.fn(),
   remove: jest.fn(),
@@ -110,6 +111,15 @@ describe('UsersController', () => {
         undefined,
         UserRole.ADMIN,
       );
+    });
+
+    it('should return active assignable users for current role', async () => {
+      mockUsersService.findAssignableUsers.mockResolvedValue([mockUser]);
+
+      const result = await controller.findAssignableUsers();
+
+      expect(result).toEqual([mockUser]);
+      expect(mockUsersService.findAssignableUsers).toHaveBeenCalledWith();
     });
   });
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -104,6 +104,16 @@ export class UsersController {
     return this.usersService.findAll(role, active, currentUser.role);
   }
 
+  @Get('assignees')
+  @ApiOperation({
+    summary: 'Get users available for referral assignment (active users only)',
+  })
+  @ApiResponse({ status: 200, description: 'List of assignable users' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async findAssignableUsers(): Promise<User[]> {
+    return this.usersService.findAssignableUsers();
+  }
+
   @Get(':id')
   @Roles(PrismaUserRole.ADMIN, PrismaUserRole.SYSTEM_ADMINISTRATOR)
   @ApiOperation({ summary: 'Get user by ID' })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -86,6 +86,18 @@ export class UsersService {
     });
   }
 
+  async findAssignableUsers(): Promise<User[]> {
+    return this.prisma.user.findMany({
+      where: {
+        isActive: true,
+        deletedAt: null,
+      },
+      orderBy: {
+        fullName: 'asc',
+      },
+    });
+  }
+
   async findOne(id: string): Promise<User> {
     const user = await this.prisma.user.findFirst({
       where: {


### PR DESCRIPTION
Adds a dedicated backend route (`GET /users/assignees`) and service method to return only active, non-deleted users sorted by name for referral assignment. Updates the admin API service and Referral Detail page to use this new assignee-specific query, and expands controller/API service tests to cover the new behavior.