### PR TITLE
Harden backend image by removing npm/npx

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,6 +19,10 @@ FROM node:24-alpine
 WORKDIR /app
 
 ENV NODE_ENV=production
+RUN rm -rf /usr/local/lib/node_modules/npm \
+	/usr/local/bin/npm \
+	/usr/local/bin/npx
+
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package*.json ./

--- a/helm/backend/templates/deployment.yaml
+++ b/helm/backend/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - name: migrate
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["npx", "prisma", "migrate", "deploy"]
+          command: ["node", "node_modules/prisma/build/index.js", "migrate", "deploy"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
The production backend Docker image now removes npm and npx binaries/modules to reduce runtime attack surface. To keep Prisma migrations working in the Helm migrate init container, the deployment command was updated to invoke Prisma directly with Node (`node node_modules/prisma/build/index.js migrate deploy`) instead of `npx`.